### PR TITLE
feat: opt-in library updates with offline-by-default startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ _render_*.py
 _mockup_*.py
 test_bake_menu.py
 requirements.txt
+
+native/*.part
+native/*.ready
+native/*.update.json
+native/*.update.tmp
+native/*.bak

--- a/build_release_zip.py
+++ b/build_release_zip.py
@@ -25,6 +25,7 @@ TARGET_ARCHS = "RTX 30/40/50 (sm_86/89/120 kernels, spoof 0x1B0; RTX 20 cannot r
 
 files = subprocess.check_output(["git", "ls-files"], text=True).splitlines()
 extra = [
+    "library_updates.py",
     "NeuralScreen.exe",
     "NeuralScreen.vbs",
     "NeuralScreen-diag.vbs",

--- a/commands.py
+++ b/commands.py
@@ -30,6 +30,7 @@ import channels
 import dialogs
 import pipeline
 import settings_io
+from library_updates import checker as library_checker
 from hotkeys import build_bindings, parse_binding
 from i18n import STRINGS as UI_STRINGS
 from paths import BASE_DIR
@@ -181,6 +182,12 @@ def apply_menu_action(st, action: tuple) -> None:
         st.cfg["rec_indicator"] = not bool(st.cfg.get("rec_indicator", True))
         settings_io.save_menu_layout(st)
         print(f"[main] recording indicator: {'on' if st.cfg['rec_indicator'] else 'off'}")
+    elif kind == "toggle" and action[1] == "library_updates_enabled":
+        enabled = not bool(st.cfg.get("library_updates_enabled", False))
+        st.cfg["library_updates_enabled"] = enabled
+        settings_io.save_menu_layout(st)
+        if enabled:
+            library_checker.start()
     elif kind == "toggle" and action[1] == "skip_static":
         # A per-frame flag in the header, not a worker setting: no restart,
         # the next frame already carries the new state.
@@ -294,6 +301,8 @@ def apply_menu_action(st, action: tuple) -> None:
     elif kind == "button":
         name = action[1]
         if name == "close":
+            if getattr(st.display.menu, "page", None) == "updates":
+                st.display.menu.page = "main"
             st.display.menu.visible = False
             st.display.set_menu_opaque(False)
             st.display.set_menu_input(False)
@@ -304,6 +313,12 @@ def apply_menu_action(st, action: tuple) -> None:
             st.running = False
         elif name == "record":
             st.tray_commands.put("record")
+        elif name == "check_libraries":
+            library_checker.start()
+        elif name == "update_libraries":
+            library_checker.update_all()
+        elif name.startswith("update_library:"):
+            library_checker.update(name.split(":", 1)[1])
         elif name == "screenshot":
             st.tray_commands.put("screenshot_menu")
         elif name == "window_mode":

--- a/docs/LIBRARY_UPDATES.md
+++ b/docs/LIBRARY_UPDATES.md
@@ -1,0 +1,19 @@
+# Optional DLSS library updates
+
+NeuralScreen makes no update requests by default. In Settings, enable
+**Check library updates automatically** to contact NVIDIA's GitHub repository
+at startup. The switch is saved as `library_updates_enabled: true`.
+**Check official versions** explicitly performs a one-time check without enabling
+automatic startup checks. Turning the switch off disables future automatic checks.
+
+The startup notification has Update and Close buttons. Updates are downloaded
+only after an explicit click, verified against the official repository blob hash
+and the expected DLL version, then staged for the next launch. Installed DLLs
+are backed up as `.bak`. Running libraries are never replaced live.
+
+The official source currently publishes SR and FG libraries. NR has no public
+update source here; the checker does not claim its local version is current.
+Network failures leave processing available and report an unknown version.
+
+`runtime/python.exe tests/test_library_updates.py` runs entirely offline:
+socket connections are forbidden by the test fixture; network responses are mocked.

--- a/i18n.py
+++ b/i18n.py
@@ -1507,3 +1507,47 @@ STRINGS = {
 def tr(lang: str, key: str) -> str:
     """Translate a STRINGS key; an unknown key comes back unchanged."""
     return STRINGS.get(lang, STRINGS[DEFAULT_LANG]).get(key, key)
+
+for _table in STRINGS.values():
+    _table.update({
+        "lib_section": "DLSS library versions",
+        "lib_check": "Check official versions",
+        "lib_checking": "Checking versions…",
+        "lib_update": "Update available",
+        "lib_install": "Update",
+        "lib_notice": "Library updates available",
+        "lib_close": "Close",
+        "lib_downloading": "Downloading update…",
+        "lib_download_failed": "Download failed — retry",
+        "lib_install_failed": "Installation failed — retry update",
+        "lib_pending": "Update ready — restart the app",
+        "lib_current": "Matches official version",
+        "lib_newer": "Local version is newer",
+        "lib_no_source": "No public update source",
+        "lib_missing": "Library not found",
+        "lib_unknown": "Could not verify version",
+    })
+STRINGS["ru"].update({
+    "lib_section": "Версии библиотек DLSS",
+    "lib_check": "Проверить официальные версии",
+    "lib_checking": "Проверка версий…",
+    "lib_update": "Доступно обновление",
+    "lib_install": "Обновить",
+    "lib_notice": "Доступны новые версии библиотек",
+    "lib_close": "Закрыть",
+    "lib_downloading": "Загрузка обновления…",
+    "lib_download_failed": "Ошибка загрузки — повторите",
+    "lib_install_failed": "Ошибка установки — повторите обновление",
+    "lib_pending": "Загружено — перезапустите программу",
+    "lib_current": "Совпадает с официальной версией",
+    "lib_newer": "Локальная версия новее",
+    "lib_no_source": "Нет публичного источника обновлений",
+    "lib_missing": "Библиотека не найдена",
+    "lib_unknown": "Не удалось проверить версию",
+})
+
+for _table in STRINGS.values():
+    _table["lib_opt_in"] = "Check library updates automatically"
+    _table["lib_opt_in_hint"] = "connects to NVIDIA on GitHub; off by default"
+STRINGS["ru"]["lib_opt_in"] = "Автоматически проверять обновления библиотек"
+STRINGS["ru"]["lib_opt_in_hint"] = "обращается к NVIDIA на GitHub; по умолчанию выключено"

--- a/library_updates.py
+++ b/library_updates.py
@@ -1,0 +1,313 @@
+"""DLSS checks and staged updates; loaded libraries are never replaced live."""
+import hashlib
+import json
+import shutil
+import time
+import os
+import ctypes
+import re
+import struct
+import threading
+import urllib.request
+
+from paths import NATIVE_DIR
+
+UPDATABLE = {'DLSS SR': 'nvngx_dlss.dll', 'DLSS FG': 'nvngx_dlssg.dll'}
+INSTALL_ERRORS = set()
+
+
+def stage_update(filename, expected, directory=NATIVE_DIR):
+    """Download official bytes, verify repository blob hash and PE version."""
+    if filename not in UPDATABLE.values():
+        raise ValueError('Unsupported library')
+    url = ('https://api.github.com/repos/NVIDIA/DLSS/contents/'
+           'lib/Windows_x86_64/rel/' + filename)
+    request = urllib.request.Request(url, headers={
+        'User-Agent': 'NeuralScreen-library-update',
+        'Accept': 'application/vnd.github.object+json'})
+    with urllib.request.urlopen(request, timeout=15) as response:
+        raw = response.read(65537)
+        if len(raw) > 65536:
+            raise ValueError('Oversized metadata')
+        meta = json.loads(raw)
+    size, sha = meta['size'], meta['sha']
+    download = meta['download_url']
+    if (meta.get('type') != 'file' or meta.get('name') != filename
+            or not isinstance(size, int) or not 4096 <= size <= 100 * 1024 * 1024
+            or not re.fullmatch('[0-9a-f]{40}', sha)
+            or not download.startswith('https://raw.githubusercontent.com/NVIDIA/DLSS/')
+            or not download.endswith('/lib/Windows_x86_64/rel/' + filename)):
+        raise ValueError('Invalid official metadata')
+    part = directory / (filename + '.part')
+    ready = directory / (filename + '.ready')
+    manifest = directory / (filename + '.update.json')
+    temp_manifest = directory / (filename + '.update.tmp')
+    blob = hashlib.sha1(f'blob {size}\0'.encode())
+    digest = hashlib.sha256()
+    received = 0
+    deadline = time.monotonic() + 180
+    try:
+        with urllib.request.urlopen(urllib.request.Request(download, headers={
+                'User-Agent': 'NeuralScreen-library-update'}), timeout=15) as response, part.open('wb') as out:
+            if response.status != 200:
+                raise ValueError('Incomplete download response')
+            while True:
+                chunk = response.read(256 * 1024)
+                if not chunk:
+                    break
+                received += len(chunk)
+                if received > size or time.monotonic() > deadline:
+                    raise ValueError('Download exceeded size or time limit')
+                blob.update(chunk)
+                digest.update(chunk)
+                out.write(chunk)
+            out.flush()
+            os.fsync(out.fileno())
+        if received != size or blob.hexdigest() != sha:
+            raise ValueError('Downloaded bytes do not match official repository')
+        if local_version(part) != expected:
+            raise ValueError('Published version changed; check versions again')
+        os.replace(part, ready)
+        temp_manifest.write_text(json.dumps({'version': expected, 'sha256': digest.hexdigest()}), encoding='utf-8')
+        os.replace(temp_manifest, manifest)
+    finally:
+        part.unlink(missing_ok=True)
+        temp_manifest.unlink(missing_ok=True)
+
+
+def apply_pending(directory=NATIVE_DIR):
+    """Called before the first worker starts. Keep an original .bak on success."""
+    for filename in UPDATABLE.values():
+        manifest = directory / (filename + '.update.json')
+        if not manifest.exists():
+            continue
+        ready = directory / (filename + '.ready')
+        target = directory / filename
+        try:
+            if manifest.stat().st_size > 4096 or ready.stat().st_size > 100 * 1024 * 1024:
+                raise ValueError('Oversized staged update')
+            meta = json.loads(manifest.read_text(encoding='utf-8'))
+            with ready.open('rb') as stream:
+                digest = hashlib.file_digest(stream, 'sha256').hexdigest()
+            version = local_version(ready)
+            if digest != meta['sha256'] or list(version) != meta['version']:
+                raise ValueError('Staged update failed integrity check')
+            if target.exists():
+                if local_version(target) >= version:
+                    manifest.unlink()
+                    ready.unlink()
+                    continue
+                shutil.copy2(target, directory / (filename + '.bak'))
+            os.replace(ready, target)
+            manifest.unlink()
+            print(f'[libraries] installed {filename} {version_text(version)}')
+            INSTALL_ERRORS.discard(filename)
+        except Exception as exc:
+            # A running second instance may lock the DLL: retain the update for retry.
+            print(f'[libraries] could not install {filename}: {exc}')
+            INSTALL_ERRORS.add(filename)
+
+
+def file_version(read):
+    """Extract fixed file version from a PE resource section without loading code."""
+    header = read(0, 4096)
+    if header[:2] != b'MZ':
+        raise ValueError('Not a PE file')
+    pe = struct.unpack_from('<I', header, 60)[0]
+    if pe > 3072 or header[pe:pe + 4] != b'PE\0\0':
+        raise ValueError('Invalid PE header')
+    count = struct.unpack_from('<H', header, pe + 6)[0]
+    optional = struct.unpack_from('<H', header, pe + 20)[0]
+    table = pe + 24 + optional
+    if not 0 < count <= 32 or table + count * 40 > len(header):
+        raise ValueError('Invalid section table')
+    for index in range(count):
+        pos = table + index * 40
+        if header[pos:pos + 8].rstrip(b'\0') != b'.rsrc':
+            continue
+        size, offset = struct.unpack_from('<II', header, pos + 16)
+        if not 0 < size <= 1024 * 1024 or offset < 4096:
+            raise ValueError('Invalid resource size')
+        resource = read(offset, size)
+        key = 'VS_VERSION_INFO\0'.encode('utf-16le')
+        start = resource.find(key)
+        if start < 6:
+            raise ValueError('Missing version resource')
+        fixed = (start + len(key) + 3) & ~3
+        signature, version, ms, ls = struct.unpack_from('<IIII', resource, fixed)
+        if signature != 0xFEEF04BD or version != 0x10000:
+            raise ValueError('Invalid fixed version')
+        return (ms >> 16, ms & 65535, ls >> 16, ls & 65535)
+    raise ValueError('No resource section')
+
+
+def local_version(path):
+    # VERSION APIs read resources without loading/executing the library.
+    if not os.path.isfile(path):
+        raise FileNotFoundError(path)
+    api = ctypes.WinDLL('version', use_last_error=True)
+    api.GetFileVersionInfoSizeW.argtypes = [ctypes.c_wchar_p, ctypes.c_void_p]
+    api.GetFileVersionInfoSizeW.restype = ctypes.c_uint32
+    api.GetFileVersionInfoW.argtypes = [ctypes.c_wchar_p, ctypes.c_uint32,
+                                      ctypes.c_uint32, ctypes.c_void_p]
+    api.VerQueryValueW.argtypes = [ctypes.c_void_p, ctypes.c_wchar_p,
+                                 ctypes.POINTER(ctypes.c_void_p),
+                                 ctypes.POINTER(ctypes.c_uint32)]
+    size = api.GetFileVersionInfoSizeW(str(path), None)
+    if not 0 < size <= 1024 * 1024:
+        raise ValueError('Missing or oversized version metadata')
+    data = ctypes.create_string_buffer(size)
+    if not api.GetFileVersionInfoW(str(path), 0, size, data):
+        raise ctypes.WinError(ctypes.get_last_error())
+    pointer, length = ctypes.c_void_p(), ctypes.c_uint32()
+    if not api.VerQueryValueW(data, '\\', ctypes.byref(pointer), ctypes.byref(length)) or length.value < 52:
+        raise ValueError('Missing fixed version')
+    signature, version, ms, ls = struct.unpack('<IIII', ctypes.string_at(pointer, 16))
+    if signature != 0xFEEF04BD or version != 0x10000:
+        raise ValueError('Invalid fixed version')
+    return (ms >> 16, ms & 65535, ls >> 16, ls & 65535)
+
+
+def remote_version(filename):
+    url = ('https://raw.githubusercontent.com/NVIDIA/DLSS/main/'
+           'lib/Windows_x86_64/rel/' + filename)
+    etag = None
+
+    def read(offset, size):
+        nonlocal etag
+        request = urllib.request.Request(url, headers={
+            'User-Agent': 'NeuralScreen-library-check',
+            'Range': f'bytes={offset}-{offset + size - 1}',
+            'Cache-Control': 'no-cache',
+        })
+        with urllib.request.urlopen(request, timeout=10) as response:
+            content_range = response.headers.get('Content-Range', '')
+            if response.status != 206 or not re.fullmatch(
+                    rf'bytes {offset}-{offset + size - 1}/\d+', content_range):
+                raise ValueError('Server did not honor bounded range request')
+            current = response.headers.get('ETag')
+            if not current or (etag is not None and current != etag):
+                raise ValueError('Remote library changed during check')
+            etag = current
+            data = response.read(size + 1)
+            if len(data) != size:
+                raise ValueError('Truncated or oversized range response')
+            return data
+    return file_version(read)
+
+
+def version_text(version):
+    return '.'.join(map(str, version)) if version else '?'
+
+
+class LibraryChecker:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.busy = False
+        self.rows = ()
+        self.notice_shown = False
+
+    def take_notice(self):
+        with self.lock:
+            if self.notice_shown or self.busy or not any(r[3] == 'update' for r in self.rows):
+                return False
+            self.notice_shown = True
+            return True
+
+    def update_all(self):
+        with self.lock:
+            if self.busy:
+                return False
+            todo = [(r[0], tuple(map(int, r[2].split('.')))) for r in self.rows
+                    if r[0] in UPDATABLE and r[3] in ('update', 'download_failed', 'install_failed') and r[2] != '?']
+            if not todo:
+                return False
+            self.busy = True
+        threading.Thread(target=self._batch, args=(todo,), name='library-download', daemon=True).start()
+        return True
+
+    def _batch(self, todo):
+        try:
+            for label, expected in todo:
+                with self.lock:
+                    self.rows = tuple((*r[:3], 'downloading') if r[0] == label else r for r in self.rows)
+                self._download(label, expected, finish=False)
+        finally:
+            with self.lock:
+                self.busy = False
+
+    def snapshot(self):
+        with self.lock:
+            return self.busy, self.rows
+
+    def start(self):
+        with self.lock:
+            if self.busy:
+                return False
+            self.busy = True
+        threading.Thread(target=self._run, name='library-updates', daemon=True).start()
+        return True
+
+    def update(self, label):
+        with self.lock:
+            row = next((r for r in self.rows if r[0] == label), None)
+            if self.busy or label not in UPDATABLE or not row or row[3] not in ('update', 'download_failed', 'install_failed') or row[2] == '?':
+                return False
+            expected = tuple(map(int, row[2].split('.')))
+            self.busy = True
+            self.rows = tuple((*r[:3], 'downloading') if r[0] == label else r for r in self.rows)
+        threading.Thread(target=self._download, args=(label, expected),
+                         name='library-download', daemon=True).start()
+        return True
+
+    def _download(self, label, expected, finish=True):
+        status = 'pending'
+        try:
+            stage_update(UPDATABLE[label], expected)
+            print(f'[libraries] {label}: update ready; restart to install')
+        except Exception as exc:
+            status = 'download_failed'
+            print(f'[libraries] {label}: download failed: {exc}')
+        finally:
+            with self.lock:
+                self.rows = tuple((*r[:3], status) if r[0] == label else r for r in self.rows)
+                if finish:
+                    self.busy = False
+
+    def _run(self):
+        rows = []
+        try:
+            for label, filename in [('DLSS SR', 'nvngx_dlss.dll'),
+                                    ('DLSS FG', 'nvngx_dlssg.dll'),
+                                    ('DLSS NR', 'nvngx_dlssnr.dll')]:
+                path = (os.environ.get('NS_NR_DLL') if label == 'DLSS NR' else None)
+                path = path or NATIVE_DIR / filename
+                installed = latest = None
+                try:
+                    installed = local_version(path)
+                    status = 'no_source' if label == 'DLSS NR' else 'unknown'
+                except FileNotFoundError:
+                    status = 'missing'
+                except Exception as exc:
+                    status = 'unknown'
+                    print(f'[libraries] {label}: local version unavailable: {exc}')
+                if label != 'DLSS NR':
+                    try:
+                        latest = remote_version(filename)
+                        if installed:
+                            status = ('update' if latest > installed else
+                                      'newer' if installed > latest else 'current')
+                    except Exception as exc:
+                        print(f'[libraries] {label}: official version unavailable: {exc}')
+                if label in UPDATABLE and (NATIVE_DIR / (filename + '.update.json')).exists():
+                    status = 'install_failed' if filename in INSTALL_ERRORS else 'pending'
+                rows.append((label, version_text(installed), version_text(latest), status))
+                print(f'[libraries] {label}: installed={version_text(installed)}, '
+                      f'official={version_text(latest)}, status={status}')
+        finally:
+            with self.lock:
+                self.rows = tuple(rows)
+                self.busy = False
+
+
+checker = LibraryChecker()

--- a/main.py
+++ b/main.py
@@ -524,6 +524,7 @@ def main() -> int:
                 # nothing", which is a report we have had (issue #27) and a
                 # notice a user asked for (issue #33). Once per session.
                 settings_io.warn_hdr(st)
+                settings_io.show_update_notice(st)
 
             # --- Input for the overlay menu --------------------------
             # Events are read only while the menu is open: the rest of the

--- a/overlay_ui.py
+++ b/overlay_ui.py
@@ -164,6 +164,8 @@ class OverlayMenu:
         self.visible = False
         self.lang = "en"
         self.state: dict = {
+            "library_updates": (False, ()),
+            "library_updates_enabled": False,
             "nr": True,
             "work_scale": 1.0,
             # Where the work size hits the NGX cap. Sent by main because only it
@@ -576,7 +578,26 @@ class OverlayMenu:
         # The windows page: the full list of capturable windows, one row per
         # window. Hovering a row highlights the real window's outline on the
         # screen (main draws the frame); clicking switches the capture.
-        if self.page == "windows":
+        if self.page == "updates":
+            section(s["lib_notice"])
+            busy, libraries = self.state["library_updates"]
+            for label, installed, latest, status in libraries:
+                if status in ("current", "no_source", "newer", "unknown", "missing"):
+                    continue
+                for caption, value in ((label, installed + " → " + latest),
+                                       (s["lib_" + status], "")):
+                    items.append(Item("info", label + caption,
+                                      pygame.Rect(pad, cy, inner_w, self._u(LABEL_H)),
+                                      extra={"label": caption, "value": value}))
+                    cy += self._u(LABEL_H) + gap
+            if not busy and any(r[3] in ("update", "download_failed", "install_failed") for r in libraries):
+                items.append(Item("button", "update_libraries", pygame.Rect(pad, cy, inner_w, act_h),
+                                  extra={"label": s["lib_install"], "filled": True}))
+                cy += act_h + gap
+            items.append(Item("button", "close", pygame.Rect(pad, cy, inner_w, act_h),
+                              extra={"label": s["lib_close"], "filled": False}))
+            cy += act_h + gap
+        elif self.page == "windows":
             section(s["sec_windows"])
             wins = self.state.get("windows") or []
             if not wins:
@@ -696,6 +717,30 @@ class OverlayMenu:
             # non-interactive kind the drawer supports - with the label as
             # its caption.
             channel = self.state.get("channel") or ""
+            section(s["lib_section"])
+            toggle("library_updates_enabled", s["lib_opt_in"],
+                   bool(self.state.get("library_updates_enabled")), hint=s["lib_opt_in_hint"])
+            busy, libraries = self.state.get("library_updates", (False, ()))
+            act_h = self._u(ACTION_H)
+            items.append(Item("button", "check_libraries",
+                              pygame.Rect(pad, cy, inner_w, act_h),
+                              extra={"label": s["lib_checking" if busy else "lib_check"],
+                                     "filled": False}))
+            cy += act_h + gap
+            for label, installed, latest, status in libraries:
+                for suffix, caption, value in (
+                        ("version", label, installed + (" → " + latest if latest != "?" else "")),
+                        ("status", s["lib_" + status], "")):
+                    items.append(Item("info", label + suffix,
+                                      pygame.Rect(pad, cy, inner_w, self._u(LABEL_H)),
+                                      extra={"label": caption, "value": value}))
+                    cy += self._u(LABEL_H) + gap
+                if status in ("update", "download_failed", "install_failed") and not busy and latest != "?":
+                    items.append(Item("button", "update_library:" + label,
+                                      pygame.Rect(pad, cy, inner_w, act_h),
+                                      extra={"label": s["lib_install"] + " " + label,
+                                             "filled": False}))
+                    cy += act_h + gap
             if channel:
                 section(s["sec_about"])
                 act_h = self._u(ACTION_H)
@@ -858,7 +903,7 @@ class OverlayMenu:
                               extra={"label": s["back"],
                                      "filled": False}))
             cy += act_h + pad
-        else:
+        elif self.page != "updates":
             # The name and nothing else, centred: the key and the
             # explanation under it turned one button into a paragraph.
             items.append(Item("action", "exit",

--- a/settings_io.py
+++ b/settings_io.py
@@ -24,6 +24,22 @@ from i18n import STRINGS as UI_STRINGS
 # numbers size the shared motion buffer in the SHMI handshake.
 from protocol import WORK_MAX_H, WORK_MAX_W  # noqa: F401
 from winapi import list_capturable_windows
+from library_updates import checker as library_checker
+
+
+def show_update_notice(st):
+    if not library_checker.take_notice():
+        return
+    menu = st.display.menu
+    menu.set_state(menu_payload(st))
+    menu.page = "updates"
+    menu.scroll = 0
+    menu.open_choice = None
+    menu.capturing = None
+    menu.visible = True
+    st.display.set_menu_opaque(True)
+    st.display.set_menu_input(True)
+    print('[libraries] startup update notice opened')
 
 
 def _work_size(width: int, height: int, scale: float) -> tuple[int, int]:
@@ -568,6 +584,7 @@ def menu_payload(st) -> dict:
         "screenshot_dir": st.cfg.get("screenshot_dir") or "",
         "spout": bool(st.cfg.get("spout", False)),
         "skip_static": bool(st.cfg.get("skip_static", True)),
+        "library_updates_enabled": st.cfg.get("library_updates_enabled", False) is True,
         # Is the network idling on an unchanged screen right now? The
         # worker says so in its log; without this the menu shows a
         # healthy FPS while nothing is being processed, and the skip
@@ -607,6 +624,7 @@ def menu_payload(st) -> dict:
             (f"{h:X}: {t}" for h, t in wins if h == st.window_hwnd), ""),
         "version": APP_VERSION,
         "channel": CHANNEL_LABEL,
+        "library_updates": library_checker.snapshot(),
     }
 
 

--- a/startup.py
+++ b/startup.py
@@ -81,6 +81,13 @@ def _apply_nr_dll(cfg: dict) -> None:
         os.environ["NS_NR_DLL"] = str(cfg["nr_dll"])
 
 
+def _start_library_checks(cfg: dict) -> None:
+    """Network access requires explicit saved opt-in; absent means offline."""
+    if cfg.get("library_updates_enabled", False) is True:
+        from library_updates import checker
+        checker.start()
+
+
 def _apply_spout_env(cfg: dict) -> None:
     """The Spout2 bridge flag reaches the worker through the environment.
 
@@ -225,6 +232,8 @@ def configure(st) -> None:
     not. Everything else lands on the state: the config, the NR parameters,
     the presets, the monitor and the resolution the pipeline will run at.
     """
+    from library_updates import apply_pending
+    apply_pending()
     st.cfg = load_config(st.cfg_path)
     st.params = resolve_params(st.cfg)
     st.presets = load_presets(st.cfg)
@@ -498,3 +507,4 @@ def bring_up(st) -> None:
     st.next_auto_revive = 0.0      # monotonic deadline; 0 = no revive pending
     st.consecutive_restarts = 0
     st.guide_fails = 0
+    _start_library_checks(st.cfg)

--- a/tests/test_library_updates.py
+++ b/tests/test_library_updates.py
@@ -1,0 +1,204 @@
+"""Version checks never replace DLLs or report an offline check as current."""
+import os
+from pathlib import Path
+import struct
+import sys
+import threading
+import tempfile
+import hashlib
+import json
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import library_updates as updates
+
+
+class Checks(unittest.TestCase):
+    def setUp(self):
+        guard = patch('socket.create_connection', side_effect=AssertionError('Tests must stay offline'))
+        guard.start()
+        self.addCleanup(guard.stop)
+
+    def test_startup_is_offline_by_default(self):
+        import startup
+        with patch.object(updates.checker, 'start') as start:
+            for cfg in ({}, {'library_updates_enabled': False}, {'library_updates_enabled': 'true'}):
+                startup._start_library_checks(cfg)
+            start.assert_not_called()
+            startup._start_library_checks({'library_updates_enabled': True})
+            start.assert_called_once()
+    def test_notice_once_and_batch(self):
+        checker = updates.LibraryChecker()
+        self.assertFalse(checker.take_notice())
+        checker.rows = (('DLSS SR', '310.8.0.0', '310.9.1.0', 'update'),
+                        ('DLSS FG', '310.8.0.0', '310.9.1.0', 'update'))
+        checker.busy = True
+        self.assertFalse(checker.take_notice())
+        checker.busy = False
+        self.assertTrue(checker.take_notice())
+        self.assertFalse(checker.take_notice())
+        with patch.object(updates, 'stage_update') as download:
+            self.assertTrue(checker.update_all())
+            for thread in threading.enumerate():
+                if thread.name == 'library-download':
+                    thread.join(3)
+        self.assertEqual(download.call_count, 2)
+        self.assertFalse(checker.snapshot()[0])
+        self.assertTrue(all(r[3] == 'pending' for r in checker.snapshot()[1]))
+
+    def test_notice_buttons(self):
+        os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+        import pygame
+        from test_ui_buttons import build, paint, find, click
+        import commands
+        from types import SimpleNamespace
+        pygame.init()
+        try:
+            menu = build()
+            menu.page = 'updates'
+            menu.set_state({'library_updates': (False, (
+                ('DLSS SR', '310.8.0.0', '310.9.1.0', 'update'),))})
+            paint(menu)
+            button = find(menu, 'button', 'update_libraries')
+            self.assertIsNotNone(button)
+            self.assertEqual(click(menu, button), [('button', 'update_libraries')])
+            with patch.object(commands.library_checker, 'update_all') as update:
+                commands.apply_menu_action(None, ('button', 'update_libraries'))
+                update.assert_called_once()
+            self.assertIsNotNone(find(menu, 'button', 'close'))
+            self.assertIsNone(find(menu, 'action', 'exit'))
+            state = SimpleNamespace(display=SimpleNamespace(menu=menu,
+                set_menu_opaque=lambda _: None, set_menu_input=lambda _: None))
+            with patch.object(commands.settings_io, 'save_menu_layout'):
+                commands.apply_menu_action(state, ('button', 'close'))
+            self.assertFalse(menu.visible)
+            self.assertEqual(menu.page, 'main')
+        finally:
+            pygame.quit()
+
+    def test_install_and_backup(self):
+        with tempfile.TemporaryDirectory() as folder:
+            directory = Path(folder)
+            target = directory / 'nvngx_dlss.dll'
+            ready = directory / 'nvngx_dlss.dll.ready'
+            manifest = directory / 'nvngx_dlss.dll.update.json'
+            target.write_bytes(b'old')
+            ready.write_bytes(b'new')
+            manifest.write_text(json.dumps({'version': [310, 10, 0, 0],
+                'sha256': hashlib.sha256(b'new').hexdigest()}))
+            def version(path):
+                return (310, 10 if Path(path).read_bytes() == b'new' else 9, 0, 0)
+            with patch.object(updates, 'local_version', side_effect=version):
+                updates.apply_pending(directory)
+            self.assertEqual(target.read_bytes(), b'new')
+            self.assertEqual((directory / 'nvngx_dlss.dll.bak').read_bytes(), b'old')
+            self.assertFalse(manifest.exists())
+            ready.write_bytes(b'corrupt')
+            manifest.write_text(json.dumps({'version': [310, 11, 0, 0], 'sha256': 'wrong'}))
+            with patch.object(updates, 'local_version', return_value=(310, 11, 0, 0)):
+                updates.apply_pending(directory)
+            self.assertEqual(target.read_bytes(), b'new')
+            self.assertTrue(manifest.exists())
+
+    def test_download_failure_can_retry(self):
+        checker = updates.LibraryChecker()
+        checker.rows = (('DLSS SR', '310.8.0.0', '310.9.1.0', 'update'),)
+        with patch.object(updates, 'stage_update', side_effect=OSError('offline')):
+            checker._download('DLSS SR', (310, 9, 1, 0))
+        self.assertEqual(checker.snapshot()[1][0][3], 'download_failed')
+        self.assertFalse(checker.snapshot()[0])
+        self.assertFalse(checker.update('DLSS NR'))
+        with patch.object(updates, 'stage_update'):
+            checker._download('DLSS SR', (310, 9, 1, 0))
+        self.assertEqual(checker.snapshot()[1][0][3], 'pending')
+        self.assertFalse(checker.update('DLSS SR'))
+
+    def test_pe_metadata(self):
+        data = bytearray(8192)
+        data[:2] = b'MZ'
+        struct.pack_into('<I', data, 60, 128)
+        data[128:132] = b'PE\0\0'
+        struct.pack_into('<H', data, 134, 1)
+        data[152:160] = b'.rsrc\0\0\0'
+        struct.pack_into('<II', data, 168, 4096, 4096)
+        key = 'VS_VERSION_INFO\0'.encode('utf-16le')
+        data[4102:4102 + len(key)] = key
+        struct.pack_into('<IIII', data, 4136, 0xFEEF04BD, 0x10000,
+                         (310 << 16) | 10, 1 << 16)
+        self.assertEqual(updates.file_version(lambda o, n: data[o:o+n]), (310, 10, 1, 0))
+        struct.pack_into('<I', data, 168, 2**30)
+        with self.assertRaises(ValueError):
+            updates.file_version(lambda o, n: data[o:o+n])
+        with self.assertRaises(ValueError):
+            updates.file_version(lambda o, n: b'bad')
+
+    def test_status_and_retry(self):
+        checker = updates.LibraryChecker()
+        with patch.object(updates, 'local_version', return_value=(310, 9, 1, 0)), \
+             patch.object(updates, 'remote_version', side_effect=[(310, 10, 0, 0), (310, 8, 0, 0)]):
+            checker._run()
+        self.assertEqual([r[3] for r in checker.snapshot()[1]], ['update', 'newer', 'no_source'])
+        with patch.object(updates, 'local_version', return_value=(310, 9, 1, 0)), \
+             patch.object(updates, 'remote_version', side_effect=OSError('offline')):
+            checker._run()
+        self.assertEqual([r[3] for r in checker.snapshot()[1]], ['unknown', 'unknown', 'no_source'])
+        self.assertFalse(checker.snapshot()[0])
+
+    def test_only_one_background_job(self):
+        checker = updates.LibraryChecker()
+        entered, release = threading.Event(), threading.Event()
+        def remote(_):
+            entered.set()
+            release.wait(5)
+            return (310, 9, 1, 0)
+        with patch.object(updates, 'local_version', return_value=(310, 9, 1, 0)), \
+             patch.object(updates, 'remote_version', side_effect=remote):
+            try:
+                self.assertTrue(checker.start())
+                self.assertTrue(entered.wait(2))
+                self.assertTrue(checker.snapshot()[0])
+                self.assertFalse(checker.start())
+            finally:
+                release.set()
+                for thread in threading.enumerate():
+                    if thread.name == 'library-updates':
+                        thread.join(3)
+        self.assertFalse(checker.snapshot()[0])
+
+    def test_unbounded_server_response_rejected(self):
+        from unittest.mock import MagicMock
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.status = 200
+        with patch.object(updates.urllib.request, 'urlopen', return_value=response):
+            with self.assertRaises(ValueError):
+                updates.remote_version('nvngx_dlss.dll')
+        response.read.assert_not_called()
+
+    def test_settings_rows(self):
+        os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+        import pygame
+        from test_ui_buttons import build, paint, find
+        pygame.init()
+        try:
+            menu = build()
+            menu.page = 'settings'
+            menu.set_state({'lang': 'ru', 'library_updates': (False, (
+                ('DLSS SR', '310.8.0.0', '310.9.1.0', 'update'),
+                ('DLSS NR', '310.8.0.0', '?', 'no_source')))})
+            paint(menu)
+            self.assertIsNotNone(find(menu, 'button', 'check_libraries'))
+            self.assertIsNotNone(find(menu, 'button', 'update_library:DLSS SR'))
+            self.assertIsNone(find(menu, 'button', 'update_library:DLSS NR'))
+            self.assertEqual(find(menu, 'info', 'DLSS SRversion').extra['value'],
+                             '310.8.0.0 → 310.9.1.0')
+            self.assertEqual(find(menu, 'info', 'DLSS NRstatus').extra['label'],
+                             'Нет публичного источника обновлений')
+        finally:
+            pygame.quit()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Offer explicitly optional DLSS library checks and staged updates while preserving offline-by-default startup.

Automatic checks are disabled when `library_updates_enabled` is absent or false. A visible Settings switch explains that enabling it contacts NVIDIA on GitHub. The manual check button is an explicit one-time request and does not enable startup checks.

After an authorized check finds an update, the notification offers Update and Close. Downloads are verified against the official repository blob hash and expected file version, staged, and installed on restart with a `.bak` of the previous DLL. Running DLLs are not replaced. NR is shown as having no public update source instead of being marked current.

This independent draft PR is based directly on current main (`dbc244f`) and contains no HDR, SR rendering, frame generation or HUD detection implementation. It is separate for the product/privacy decision raised in #36.

Validation: 10 offline unit tests pass with socket connections forbidden by the fixture. They cover default-off startup, explicit opt-in, update notices, batching, retry/failure, corrupted staged files, backup/install and UI actions. Localization, configuration, UI buttons, crash reporting and module-import checks also pass. No test requires GitHub availability.
