### PR TITLE
feat: independently controlled DLSS Super Resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ _render_*.py
 _mockup_*.py
 test_bake_menu.py
 requirements.txt
+native/nvngx_dlss.dll

--- a/build_release_zip.py
+++ b/build_release_zip.py
@@ -25,6 +25,8 @@ TARGET_ARCHS = "RTX 30/40/50 (sm_86/89/120 kernels, spoof 0x1B0; RTX 20 cannot r
 
 files = subprocess.check_output(["git", "ls-files"], text=True).splitlines()
 extra = [
+    "resolution_limits.py",
+    "native/nvngx_dlss.dll",
     "NeuralScreen.exe",
     "NeuralScreen.vbs",
     "NeuralScreen-diag.vbs",

--- a/commands.py
+++ b/commands.py
@@ -181,6 +181,12 @@ def apply_menu_action(st, action: tuple) -> None:
         st.cfg["rec_indicator"] = not bool(st.cfg.get("rec_indicator", True))
         settings_io.save_menu_layout(st)
         print(f"[main] recording indicator: {'on' if st.cfg['rec_indicator'] else 'off'}")
+    elif kind == "toggle" and action[1] == "dlss_sr":
+        st.cfg["dlss_sr"] = not bool(st.cfg.get("dlss_sr", False))
+        settings_io.save_menu_layout(st)
+    elif kind == "dlss_sr_scale":
+        st.cfg["dlss_sr_scale"] = min(1.0, max(.25, float(action[1])))
+        settings_io.save_menu_layout(st)
     elif kind == "toggle" and action[1] == "skip_static":
         # A per-frame flag in the header, not a worker setting: no restart,
         # the next frame already carries the new state.

--- a/docs/SUPER_RESOLUTION.md
+++ b/docs/SUPER_RESOLUTION.md
@@ -1,0 +1,23 @@
+# Experimental DLSS Super Resolution
+
+This change adds an independently controlled DLSS input scale. Capture is
+reduced before neural rendering; DLSS SR restores the native output size.
+Boost continues to control neural resolution relative to that reduced input.
+Area filtering limits aliasing during reduction, and bounded sharpening follows SR.
+
+SR is off by default. Enable it in the processing menu. `native/nvngx_dlss.dll`
+is required and is not stored in git. Missing/failed SR falls back to neural
+rendering without SR. Processing dimensions are clamped to a safe minimum.
+
+Capture and grayscale guides are latched together before motion estimation.
+This is desktop reconstruction with estimated motion and flat depth, not an
+engine integration with ground-truth depth, motion vectors and jitter.
+
+Validation:
+- `runtime/python.exe tests/test_super_resolution.py --run`
+- `runtime/python.exe tests/test_prepared_capture.py --run`
+- `runtime/python.exe tests/test_quality_gpu.py --run`
+- `runtime/python.exe tests/test_resolution_limits.py`
+- `runtime/python.exe tests/test_motion_floor.py`
+
+The native tests require Windows and an NVIDIA GPU; shader tests use WARP and MSVC.

--- a/guides.py
+++ b/guides.py
@@ -49,9 +49,8 @@ class TemporalGuideGenerator:
         # static desktop produces small noise vectors (capture noise,
         # cursor jitter, UI shimmer). Vectors below the noise floor are
         # zeroed - NGX would otherwise treat them as real motion and smear
-        # text/UI. The floor is in flow-resolution pixels: 0.5 px at a
-        # 320-wide flow is ~6 px at 4K work resolution, far below any real
-        # motion (a 2 px scroll at 4K is 0.17 px in flow space).
+        # text/UI. The floor is in work-resolution pixels. Applying it on
+        # the small flow grid erased real 1–6 pixel scrolling at high resolution.
         self._flow_noise_floor = 0.5
 
     @property
@@ -117,8 +116,6 @@ class TemporalGuideGenerator:
                 # vectors even on a static screen (capture noise, cursor
                 # jitter); NGX would smear text/UI on them. The mask is
                 # computed on the flow grid (115k elements, not 3M).
-                mag = np.hypot(cur_to_prev[..., 0], cur_to_prev[..., 1])
-                cur_to_prev[mag < self._flow_noise_floor] = 0.0
                 # Scale BEFORE the upscale: 115k elements instead of 3M, and
                 # exactly equivalent because resize is linear (verified: the
                 # two orders differ by 0.002, i.e. float16 rounding).
@@ -126,6 +123,8 @@ class TemporalGuideGenerator:
                             out=self._flow_scaled[..., 0])
                 np.multiply(cur_to_prev[..., 1], self.height / self.flow_height,
                             out=self._flow_scaled[..., 1])
+                mag = np.hypot(self._flow_scaled[..., 0], self._flow_scaled[..., 1])
+                self._flow_scaled[mag < self._flow_noise_floor] = 0.0
                 if self.emit_small:
                     # The worker upscales it on the GPU — all that is left
                     # here is converting 115k values to float16.

--- a/i18n.py
+++ b/i18n.py
@@ -1555,3 +1555,27 @@ STRINGS = {
 def tr(lang: str, key: str) -> str:
     """Translate a STRINGS key; an unknown key comes back unchanged."""
     return STRINGS.get(lang, STRINGS[DEFAULT_LANG]).get(key, key)
+
+STRINGS['en'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
+
+STRINGS['ru'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'сеть работает на пониженном разрешении;\nDLSS восстанавливает размер кадра (эксперимент)', 'dlss_sr_failed': 'DLSS Super Resolution не сработал. Нейрорендеринг продолжает работать.', 'dlss_sr_input': 'Входное разрешение DLSS', 'nr_min_hint': 'минимальный размер обработки ограничен автоматически'})
+
+STRINGS['fr'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
+
+STRINGS['de'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
+
+STRINGS['es'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
+
+STRINGS['it'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
+
+STRINGS['pt'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
+
+STRINGS['pl'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
+
+STRINGS['uk'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
+
+STRINGS['zh'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
+
+STRINGS['ja'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
+
+STRINGS['ko'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})

--- a/i18n.py
+++ b/i18n.py
@@ -1579,3 +1579,7 @@ STRINGS['zh'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the n
 STRINGS['ja'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
 
 STRINGS['ko'].update({'dlss_sr': 'DLSS Super Resolution', 'dlss_sr_hint': 'the network runs at a lower resolution;\nDLSS restores the output resolution (experimental)', 'dlss_sr_failed': 'DLSS Super Resolution failed. Neural rendering remains active.', 'dlss_sr_input': 'DLSS input resolution', 'nr_min_hint': 'minimum processing size is limited automatically'})
+
+for _table in STRINGS.values():
+    _table["dlss_sr_hint"] += "\n100%: DLAA (native-resolution anti-aliasing; additional GPU work)."
+STRINGS["ru"]["dlss_sr_hint"] = "На пониженном разрешении DLSS восстанавливает размер кадра.\n100%: DLAA — сглаживание без апскейла, с дополнительной нагрузкой на GPU."

--- a/main.py
+++ b/main.py
@@ -141,7 +141,7 @@ from protocol import (  # noqa: F401
     SHM_MAGIC, VIDEO_MAGIC, WGC_ACK_FMT, WGC_ACK_MAGIC, WGC_FMT,
     WGC_MAGIC, WINDOW_ACK_FMT, WINDOW_ACK_MAGIC, WINDOW_FLAG_CAPTURABLE,
     WINDOW_FLAG_DISABLE, WINDOW_FMT, WINDOW_MAGIC, WorkerReader,
-    _read_exact, send_dda, send_frame, send_gray, send_motion_size,
+    _read_exact, sync_sr_scale, prepare_capture, send_dda, send_frame, send_gray, send_motion_size,
     send_out, send_resize, send_wgc, send_window)
 
 
@@ -524,6 +524,7 @@ def main() -> int:
                 # nothing", which is a report we have had (issue #27) and a
                 # notice a user asked for (issue #33). Once per session.
                 settings_io.warn_hdr(st)
+                settings_io.refresh_sr(st)
 
             # --- Input for the overlay menu --------------------------
             # Events are read only while the menu is open: the rest of the
@@ -573,32 +574,35 @@ def main() -> int:
             # parameters and carries on. This is the last line of defence:
             # the program does not fall over.
             try:
-                t0 = time.perf_counter()
-                if st.gray_active:
-                    guide = st.guides.process(gray=st.shm.read_gray())
-                else:
-                    guide = st.guides.process(st.work_frame)
-                _perf("guides", t0)
-            except Exception as guide_exc:
-                # guides is not critical: ValueError/TypeError/cv2.error (the
-                # shape of the gray frame, a division by zero) must not take
-                # the process down. We skip the frame - the worker gets the
-                # next one. But a persistent error (an incompatible gray
-                # channel, a broken shape) would spin main at 100% CPU -
-                # after 5 failures in a row we fall back to zero motion: the
-                # frames keep flowing and the picture does not freeze.
-                print(f"[main] guides.process failed ({guide_exc}) - frame skipped",
-                      file=sys.stderr)
-                st.guide_fails += 1
-                if st.guide_fails >= 5:
-                    print(f"[main] guides.process is unstable - zero motion "
-                          f"(frames keep flowing)", file=sys.stderr)
-                    st.guide_fails = 0
-                    guide = st.guides.zero_guide()
-                else:
-                    continue
-            try:
                 check_worker(st.worker, st.worker_logs)
+                sync_sr_scale(st.worker, st.reader, float(st.cfg.get("dlss_sr_scale", .65)))
+                if st.gray_active:
+                    prepare_capture(st.worker, st.reader, st.frame_index, st.pts)
+                try:
+                    t0 = time.perf_counter()
+                    if st.gray_active:
+                        guide = st.guides.process(gray=st.shm.read_gray())
+                    else:
+                        guide = st.guides.process(st.work_frame)
+                    _perf("guides", t0)
+                except Exception as guide_exc:
+                    # guides is not critical: ValueError/TypeError/cv2.error (the
+                    # shape of the gray frame, a division by zero) must not take
+                    # the process down. We skip the frame - the worker gets the
+                    # next one. But a persistent error (an incompatible gray
+                    # channel, a broken shape) would spin main at 100% CPU -
+                    # after 5 failures in a row we fall back to zero motion: the
+                    # frames keep flowing and the picture does not freeze.
+                    print(f"[main] guides.process failed ({guide_exc}) - frame skipped",
+                          file=sys.stderr)
+                    st.guide_fails += 1
+                    if st.guide_fails >= 5:
+                        print(f"[main] guides.process is unstable - zero motion "
+                              f"(frames keep flowing)", file=sys.stderr)
+                        st.guide_fails = 0
+                        guide = st.guides.zero_guide()
+                    else:
+                        continue
                 t0 = time.perf_counter()
                 send_frame(st.worker, st.frame_index, st.work_frame, guide.motion, guide.reset,
                            st.pts, st.shm, want_pixels=(st.pending_shot is not None
@@ -608,7 +612,9 @@ def main() -> int:
                            no_color=bool(st.dda_mode),
                            bypass=bypass,
                            split=st.split_pos,
-                           skip_static=bool(st.cfg.get("skip_static", True)))
+                           skip_static=bool(st.cfg.get("skip_static", True)),
+                           prepared=bool(st.gray_active),
+                           dlss_sr=bool(st.cfg.get("dlss_sr", False)))
                 _perf("send", t0)
             except (BrokenPipeError, OSError, EOFError, RuntimeError) as exc:
                 st.consecutive_restarts += 1

--- a/native/dlss5-feed-host64.cpp
+++ b/native/dlss5-feed-host64.cpp
@@ -1307,6 +1307,8 @@ static int RunTest()
 
 static constexpr uint32_t VIDEO_MAGIC     = 0x32563544u; // "D5V2" -- legacy 56-byte header
 static constexpr uint32_t VIDEO_MAGIC_EXT = 0x33563544u; // "D5V3" -- 64-byte header with full_w/full_h
+static constexpr uint32_t CAPTURE_MAGIC = 0x31504143u; // CAP1
+static constexpr uint32_t FRAME_FLAG_PREPARED = 0x1000u;
 static constexpr uint32_t FRAME_MAGIC = 0x314D5246u; // "FRM1"
 static constexpr uint32_t OUT_MAGIC   = 0x3154554Fu; // "OUT1"
 static constexpr uint32_t RESIZE_MAGIC    = 0x5A534E52u; // "RNSZ" -- reconfigure on the fly (work size + params)
@@ -1606,6 +1608,7 @@ static HdrDisplayInfo g_capture_display;
 static float g_hdr_frame_white = 1.0f;
 static UINT g_hdr_split = UINT_MAX;
 static bool PresentHdr(VideoState &v, bool bypass);
+static void CloseSrResources();
 static bool EnsurePresentFormat(bool hdr);
 static void CloseHdrResources();
 
@@ -1662,8 +1665,8 @@ static HWND                       g_present_hwnd;
 // every OpenPresent - a monitor switch restarts the worker anyway.
 static int                        g_present_x = 0;
 static int                        g_present_y = 0;
-static bool                       g_present_shown = false;      // visible right now (minimised target hides it)
-static bool                       g_present_revealed = false;   // the first Present already happened
+static bool g_present_shown = false;
+static bool g_present_revealed = false;   // the first Present already happened
 static RECT                       g_present_follow = {};   // where the target window was last seen
 // Defined here rather than with the capture code below: the present window
 // has to know whether one window is being captured, and which one, and this
@@ -1782,6 +1785,7 @@ static DWORD WINAPI PresentWindowThread(LPVOID)
 
 static void ClosePresent()
 {
+
     if (g_present_swap != nullptr) { g_present_swap->Release(); g_present_swap = nullptr; }
     if (g_present_tid != 0) PostThreadMessageW(g_present_tid, WM_QUIT, 0, 0);
     if (g_present_hwnd != nullptr) { PostMessageW(g_present_hwnd, WM_CLOSE, 0, 0); }
@@ -2174,6 +2178,17 @@ static float ResidualStrengthRequested()
 
 // want_small < 0 means "whatever NS_NR_SMALL says" - used for the very first
 // creation, before the client has had a chance to ask for anything.
+// Keep in sync with resolution_limits.py. Never manufacture a square 64x64
+// NR image from a wide capture when Boost and SR reductions compound.
+static void SafeProcessingSize(UINT sw, UINT sh, UINT &w, UINT &height)
+{
+    const UINT mw=std::min(256u,sw), mh=std::min(144u,sh);
+    if (w>=mw && height>=mh) return;
+    const double ratio=std::min(1.,std::max({double(mw)/sw,double(mh)/sh,double(w)/sw,double(height)/sh}));
+    w=std::min(sw,UINT(ceil(sw*ratio/2))*2);
+    height=std::min(sh,UINT(ceil(sh*ratio/2))*2);
+}
+
 static bool CreateVideoResources(VideoState &v, UINT w, UINT hgt, UINT full_w = 0, UINT full_h = 0,
                                  int want_small = -1)
 {
@@ -2194,6 +2209,7 @@ static bool CreateVideoResources(VideoState &v, UINT w, UINT hgt, UINT full_w = 
     v.residual_strength = v.residual ? ResidualStrengthRequested() : 1.0f;
     const UINT cw = v.upscale ? full_w : w;   // color texture: full-res in upscale mode
     const UINT ch = v.upscale ? full_h : hgt;
+    if (v.nr_small) SafeProcessingSize(cw,ch,v.nr_w,v.nr_h);
     if (!CreateVideoTex(v.color, cw, ch, DXGI_FORMAT_R8G8B8A8_UNORM, cw * 4) ||
         // ALLOW_UNORDERED_ACCESS: the motion field upscale shader writes into it
         !CreateVideoTex(v.mv, w, hgt, DXGI_FORMAT_R16G16_FLOAT, w * 4,
@@ -2328,7 +2344,8 @@ static const char kScaleHlsl[] =
     "    gDst[id.xy] = lerp(lerp(v00, v10, f.x), lerp(v01, v11, f.x), f.y);\n"
     "}\n";
 
-// The same scaler for four-channel colour (RGBA8). Kept as a separate shader
+// Area reduction / bilinear enlargement for four-channel colour (RGBA8).
+// Kept as a separate shader
 // rather than one generic float4 pass over both: the motion field is
 // R16G16_FLOAT, and a typed UAV has to match the resource format exactly.
 //
@@ -2337,28 +2354,7 @@ static const char kScaleHlsl[] =
 // the pixel count it is handed: measured 1.50 ms fixed + 1.51 ms per megapixel
 // on a 5070 Ti. Feeding it the work resolution and scaling the result back is
 // therefore worth about half the frame time at 4K.
-static const char kScaleHlsl4[] =
-    "Texture2D<float4>   gSrc : register(t0);\n"
-    "RWTexture2D<float4> gDst : register(u0);\n"
-    "cbuffer Sizes : register(b0) { uint gDstW; uint gDstH; uint gSrcW; uint gSrcH; };\n"
-    "[numthreads(8, 8, 1)]\n"
-    "void CSMain(uint3 id : SV_DispatchThreadID)\n"
-    "{\n"
-    "    if (id.x >= gDstW || id.y >= gDstH) return;\n"
-    "    float2 src = (float2(id.xy) + 0.5f) * float2(gSrcW, gSrcH)\n"
-    "                 / float2(gDstW, gDstH) - 0.5f;\n"
-    "    float2 f  = frac(src);\n"
-    "    int2   p0 = int2(floor(src));\n"
-    "    int2   hi = int2(gSrcW - 1, gSrcH - 1);\n"
-    "    int2   a  = clamp(p0,              int2(0, 0), hi);\n"
-    "    int2   b  = clamp(p0 + int2(1, 1), int2(0, 0), hi);\n"
-    "    float4 v00 = gSrc[int2(a.x, a.y)];\n"
-    "    float4 v10 = gSrc[int2(b.x, a.y)];\n"
-    "    float4 v01 = gSrc[int2(a.x, b.y)];\n"
-    "    float4 v11 = gSrc[int2(b.x, b.y)];\n"
-    "    gDst[id.xy] = lerp(lerp(v00, v10, f.x), lerp(v01, v11, f.x), f.y);\n"
-    "}\n";
-
+#include "quality_shaders.h"
 // Matched residual composite (the DLSSNR-Cost-Scaler principle): run the
 // network at the work resolution, then compose the neural delta onto the
 // pristine 1:1 native frame instead of stretching the low-res result.
@@ -2400,6 +2396,7 @@ static ID3D12DescriptorHeap *g_scale_heap;
 static ID3D12Resource       *g_scale_src_bound;   // which resources already have descriptors
 static ID3D12Resource       *g_scale_dst_bound;
 static ID3D12PipelineState  *g_scale4_pso;        // the RGBA8 variant, for colour
+static ID3D12PipelineState  *g_sharpen_pso;
 static ID3D12DescriptorHeap *g_scale4_heap;
 static ID3D12Resource       *g_scale4_src_bound;   // slot 0: the downscale pair
 static ID3D12Resource       *g_scale4_dst_bound;
@@ -2434,7 +2431,7 @@ static void CloseMotionScaler()
 // Shader and root signature compilation - once per process lifetime.
 static bool EnsureScalePipeline()
 {
-    if (g_scale_pso != nullptr) return true;
+    if (g_scale_pso != nullptr) return g_scale4_pso && g_sharpen_pso && g_residual_pso;
 
     HMODULE compiler = LoadLibraryW(L"d3dcompiler_47.dll");
     auto compile = compiler ? reinterpret_cast<PFN_D3DCompile_>(
@@ -2543,12 +2540,26 @@ static bool EnsureScalePipeline()
                                            reinterpret_cast<void **>(&g_scale4_pso));
     code4->Release();
     if (FAILED(hr)) { Log("[scale] colour pipeline failed 0x%08X", hr); return false; }
+    ID3DBlob *sharp_code=nullptr; errors=nullptr;
+    hr=compile(kSharpenHlsl,sizeof(kSharpenHlsl)-1,"sharpen.hlsl",nullptr,nullptr,
+               "CSMain","cs_5_0",0,0,&sharp_code,&errors);
+    if (FAILED(hr) || !sharp_code) {
+        Log("[scale] sharpening shader failed 0x%08X: %s",hr,
+            errors ? static_cast<const char*>(errors->GetBufferPointer()) : "no log");
+        if(errors) errors->Release();
+        return false;
+    }
+    if(errors) errors->Release();
+    pd.CS.pShaderBytecode=sharp_code->GetBufferPointer();pd.CS.BytecodeLength=sharp_code->GetBufferSize();
+    hr=h.dev->CreateComputePipelineState(&pd,__uuidof(ID3D12PipelineState),reinterpret_cast<void**>(&g_sharpen_pso));
+    sharp_code->Release();
+    if(FAILED(hr)) return false;
     hd.NumDescriptors = 4;   // two SRV/UAV pairs: one to scale down, one up
     hr = h.dev->CreateDescriptorHeap(&hd, __uuidof(ID3D12DescriptorHeap),
                                      reinterpret_cast<void **>(&g_scale4_heap));
     if (FAILED(hr)) { Log("[scale] colour descriptor heap failed 0x%08X", hr); return false; }
 
-    Log("[scale] compute pipeline ready (bilinear, clamp; motion and colour)");
+    Log("[scale] compute pipeline ready (area downscale, bilinear upscale; bounded sharpening)");
 
     // --- Matched residual composite pipeline -------------------------------
     // Three SRVs (native, nr_in, nr_out) + one UAV (dst), a 32-bit-constants
@@ -2690,7 +2701,7 @@ static void BindScale4Descriptors(ID3D12Resource *src, ID3D12Resource *dst, UINT
     *bound_dst = dst;
 }
 
-// Bilinear-scale one RGBA8 texture into another, inside an already open
+// Scale one RGBA8 texture into another, inside an already open
 // command list. Barriers are the caller's: only it knows what these resources
 // were doing before and after, and guessing here would mean transitioning
 // twice on every frame.
@@ -2877,6 +2888,7 @@ static void CloseGray()
 
 static void CloseDda()
 {
+
     g_dda_active = false;
     g_dda_ready = false;
     g_hdr_capture = false;
@@ -3170,6 +3182,7 @@ static bool OpenGray(const VideoGrayCmd &gc)
 // Run the AREA average g_dda_dst -> gray and write it into the client mapping.
 // Called from DdaGrab after the swizzle (it cannot be in the same Begin/End
 // block - a separate fence is needed), hence its own Begin/End here.
+static bool g_capture_gray_ok = true;
 static bool AreaToGray()
 {
     if (!g_gray_mapped || !g_dda_dst) return false;
@@ -3735,7 +3748,7 @@ static bool SwizzleCaptureIntoColor(VideoState &v)
     const UINT64 fence = EndCommands();
     if (!WaitFenceValue(h.fence, fence, 10000)) { Log("[cap] swizzle fence timeout"); return false; }
     // Hand the client the luminance frame (320x180) for the optical flow
-    if (!AreaToGray()) { /* best effort: guides go without a fresh frame */ }
+    g_capture_gray_ok = AreaToGray();
     UpdateAdaptiveExposure();
     g_dda_ready = true;
     return true;
@@ -4123,16 +4136,25 @@ static void ReadEvalGpuTime()
     g_ts_readback->Unmap(0, &none);
 }
 
+#include "super_resolution.inl"
+
 static bool EvaluateVideo(VideoState &v, int reset)
 {
+    const bool use_sr = EnsureSr(v);
     if (!BeginCommands()) return false;
     const UINT cw = v.upscale ? v.full_w : v.w;
     const UINT ch = v.upscale ? v.full_h : v.hgt;
     // What the network is actually handed. In nr_small mode that is the work
     // resolution, and colour has to be scaled down into nr_in first.
-    const UINT nw = v.nr_small ? v.nr_w : cw;
-    const UINT nh = v.nr_small ? v.nr_h : ch;
-    if (v.nr_small)
+    const UINT nw = use_sr ? g_sr.nw : (v.nr_small ? v.nr_w : cw);
+    const UINT nh = use_sr ? g_sr.nh : (v.nr_small ? v.nr_h : ch);
+    static UINT previous_nw=0, previous_nh=0;
+    static bool previous_sr=false;
+    reset = reset || previous_nw != nw || previous_nh != nh || previous_sr != use_sr ||
+            (use_sr && !g_sr.history);
+    previous_nw=nw;previous_nh=nh;previous_sr=use_sr;
+    if (use_sr) PrepareSrInput(v);
+    else if (v.nr_small)
     {
         D3D12_RESOURCE_BARRIER to_uav = Transition(
             v.nr_in, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
@@ -4149,8 +4171,8 @@ static bool EvaluateVideo(VideoState &v, int reset)
     // incomparable with every measurement taken so far.
     const bool ts = PhaseEnabled() && EnsureTimestamps();
     if (ts) h.list->EndQuery(g_ts_heap, D3D12_QUERY_TYPE_TIMESTAMP, 0);
-    ID3D12Resource *nr_color = v.nr_small ? v.nr_in : v.color.tex;
-    ID3D12Resource *nr_result = v.nr_small ? v.nr_out : v.output;
+    ID3D12Resource *nr_color = use_sr ? g_sr.nr_in.get() : (v.nr_small ? v.nr_in : v.color.tex);
+    ID3D12Resource *nr_result = use_sr ? g_sr.nr_out.get() : (v.nr_small ? v.nr_out : v.output);
     h.params->Reset();
     h.params->Set("DLSSNR.Color", nr_color); h.params->Set("DLSSNR.Output", nr_result);
     h.params->Set("DLSSNR.MVec", v.mv.tex);
@@ -4160,7 +4182,8 @@ static bool EvaluateVideo(VideoState &v, int reset)
     h.params->Set("DLSSNR.MVecSubrectWidth", v.w); h.params->Set("DLSSNR.MVecSubrectHeight", v.hgt);
     h.params->Set("DLSSNR.OutputSubrectBaseX", 0u); h.params->Set("DLSSNR.OutputSubrectBaseY", 0u);
     h.params->Set("DLSSNR.OutputSubrectWidth", nw); h.params->Set("DLSSNR.OutputSubrectHeight", nh);
-    h.params->Set("DLSSNR.MVecScaleX", 1.0f); h.params->Set("DLSSNR.MVecScaleY", 1.0f);
+    h.params->Set("DLSSNR.MVecScaleX", (use_sr || v.nr_small) ? float(nw)/v.w : 1.0f);
+    h.params->Set("DLSSNR.MVecScaleY", (use_sr || v.nr_small) ? float(nh)/v.hgt : 1.0f);
     h.params->Set("DLSSNR.Enabled", 1u); h.params->Set("DLSSNR.Reset", reset);
     h.params->Set("DLSSNR.Intensity", g_video_options.intensity);
     h.params->Set("DLSSNR.LocalToneStrength", g_video_options.local_tone);
@@ -4178,7 +4201,8 @@ static bool EvaluateVideo(VideoState &v, int reset)
     g_last_eval_result = static_cast<uint32_t>(result);
     if (code != 0) { AbortCommands(); Log("[pure] direct evaluate exception 0x%08X", code); return false; }
     if (ts) h.list->EndQuery(g_ts_heap, D3D12_QUERY_TYPE_TIMESTAMP, 1);
-    if (v.nr_small)
+    if (use_sr) { ComposeSrInput(v); EvaluateSr(v, reset); }
+    else if (v.nr_small)
     {
         // The result is work-sized; stretch it into the full-res output the
         // rest of the pipeline expects. In residual mode the work-res nr_out
@@ -4357,6 +4381,7 @@ static bool DownloadVideoFrame(VideoState &v, std::vector<BYTE> &packed,
     return true;
 }
 
+
 static bool ReShadeHasFeature18()
 {
     char path[MAX_PATH] = {};
@@ -4391,6 +4416,8 @@ static int ReadVideoMessage(VideoState &v, VideoFrameHeader &fh, std::vector<BYT
                             const BYTE **color_ptr, const BYTE **mv_ptr)
 {
     if (!ReadExact(stdin, &fh, sizeof(fh))) return 0;
+    if (fh.magic == 0x31435353u) return 11; // SSC1: independent SR input scale
+    if (fh.magic == CAPTURE_MAGIC) return 10;
     if (fh.magic == FRAME_MAGIC)
     {
         bool no_color = (fh.reserved & FRAME_FLAG_NO_COLOR) != 0;
@@ -4509,6 +4536,8 @@ static int ReadVideoMessage(VideoState &v, VideoFrameHeader &fh, std::vector<BYT
 
 static void ReleaseVideoTextures(VideoState &v)
 {
+    CloseSrResources();
+
     // The shader descriptors referenced these resources - after they are
     // released the descriptors must be reissued (see BindScaleDescriptors).
     if (v.mv.tex == g_scale_dst_bound) g_scale_dst_bound = nullptr;
@@ -4686,6 +4715,8 @@ static int RunVideo()
 
     VideoFrameHeader fh = {};
     std::vector<BYTE> color, mv, output;
+    bool prepared = false, prepared_got = false;
+    uint32_t prepared_index = 0;
     bool warmup_done = false;
     uint32_t frame = 0;
     for (;;)
@@ -4701,6 +4732,7 @@ static int RunVideo()
         const BYTE *mv_ptr = nullptr;
         const int msg = ReadVideoMessage(v, fh, color, mv, rc, sc, wc, mc, dc, gc,
                                          oc, &color_ptr, &mv_ptr);
+        if (msg != 1 && msg != 10) prepared = false;
         if (msg == 0)
         {
             if (live)
@@ -4911,6 +4943,31 @@ static int RunVideo()
             if (!WriteExact(stdout, &ack, sizeof(ack))) return 10;
             continue;
         }
+        if (msg == 11)
+        {
+            const unsigned scale=std::clamp(fh.reset,25u,100u);
+            if (g_sr.scale!=scale) {
+                CloseSrResources();g_sr.scale=scale;g_sr.failed=false;
+                g_force_next_frame=true;
+                Log("[sr] input scale: %u%% (before NR; Boost ratio unchanged)",scale);
+            }
+            VideoResultHeader ack={OUT_MAGIC,fh.index,1u,0u,0u,fh.pts};
+            if (!WriteExact(stdout,&ack,sizeof(ack))) return 10;
+            continue;
+        }
+        if (msg == 10)
+        {
+            if (!CaptureActive()) { Log("[cap] CAP1 requires active capture"); return 10; }
+            prepared_got = g_wgc_active ? WgcGrab(v) : DdaGrab(v);
+            if (g_dda_ready && g_gray_mapped && !g_capture_gray_ok)
+            { Log("[cap] gray update failed; refusing mismatched motion"); return 10; }
+            prepared_index = fh.index;
+            prepared = true;
+            VideoResultHeader ack = {OUT_MAGIC, fh.index, 1u, 0u, 0u, fh.pts};
+            if (!WriteExact(stdout, &ack, sizeof(ack))) return 10;
+            continue;
+        }
+        ConfigureSrFrame(fh.reserved);
         const double t_frame = PhaseNow();
         if (CaptureActive())
         {
@@ -4918,7 +4975,11 @@ static int RunVideo()
             // one window (WGCW) straight on the GPU, motion from the frame
             // sent in (the client keeps sending pairs).
             const double t_dda = PhaseNow();
-            const bool got = g_wgc_active ? WgcGrab(v) : DdaGrab(v);
+            const bool use_prepared = (fh.reserved & FRAME_FLAG_PREPARED) != 0;
+            if (use_prepared && (!prepared || prepared_index != fh.index))
+            { Log("[cap] prepared frame ID mismatch; refusing stale motion"); return 10; }
+            const bool got = use_prepared ? prepared_got : (g_wgc_active ? WgcGrab(v) : DdaGrab(v));
+            prepared = false;
             PhaseAdd(PH_DDA, t_dda);
             if (!got && !g_dda_ready)
             {
@@ -5020,6 +5081,7 @@ static int RunVideo()
         g_hdr_split = (fh.reserved & FRAME_FLAG_SPLIT) ?
             SplitXFromFlags(fh.reserved, v.upscale ? v.full_w : v.w) : UINT_MAX;
         const bool bypass = (fh.reserved & FRAME_FLAG_BYPASS) != 0 || h.feature == nullptr;
+        if (bypass) g_sr.history = false;
         if (!bypass)
         {
             const double t_eval = PhaseNow();
@@ -5111,6 +5173,10 @@ static int RunVideo()
 // ---------------------------------------------------------------------------
 static void CleanupVideoNgx()
 {
+
+    CloseSrResources();
+    if (g_sr.params) { NVSDK_NGX_D3D12_DestroyParameters(g_sr.params); g_sr.params = nullptr; }
+
     if (h.feature != nullptr)
     {
         SafeReleaseFeature(h.feature);

--- a/native/quality_shaders.h
+++ b/native/quality_shaders.h
@@ -1,0 +1,57 @@
+#pragma once
+
+// Area coverage for reductions; bilinear reconstruction for enlargements.
+// Filtering uses the same SDR proxy encoding as NR/SR, including alpha.
+static const char kScaleHlsl4[] = R"hlsl(
+Texture2D<float4> gSrc : register(t0);
+RWTexture2D<float4> gDst : register(u0);
+cbuffer Sizes : register(b0) { uint gDstW; uint gDstH; uint gSrcW; uint gSrcH; };
+[numthreads(8,8,1)]
+void CSMain(uint3 id : SV_DispatchThreadID) {
+    if (id.x >= gDstW || id.y >= gDstH) return;
+    int2 hi = int2(gSrcW-1,gSrcH-1);
+    if (gSrcW > gDstW || gSrcH > gDstH) {
+        float2 lo = float2(id.xy)*float2(gSrcW,gSrcH)/float2(gDstW,gDstH);
+        float2 end = float2(id.xy+1)*float2(gSrcW,gSrcH)/float2(gDstW,gDstH);
+        float4 sum = 0;
+        [loop] for (int y=int(floor(lo.y)); y<int(ceil(end.y)); ++y) {
+            float wy=max(0,min(end.y,float(y+1))-max(lo.y,float(y)));
+            [loop] for (int x=int(floor(lo.x)); x<int(ceil(end.x)); ++x) {
+                float wx=max(0,min(end.x,float(x+1))-max(lo.x,float(x)));
+                sum += gSrc[clamp(int2(x,y),int2(0,0),hi)]*wx*wy;
+            }
+        }
+        gDst[id.xy]=sum/((end.x-lo.x)*(end.y-lo.y));
+        return;
+    }
+    float2 p=(float2(id.xy)+.5)*float2(gSrcW,gSrcH)/float2(gDstW,gDstH)-.5;
+    int2 a=int2(floor(p)); float2 f=frac(p);
+    float4 tl=gSrc[clamp(a,int2(0,0),hi)];
+    float4 tr=gSrc[clamp(a+int2(1,0),int2(0,0),hi)];
+    float4 bl=gSrc[clamp(a+int2(0,1),int2(0,0),hi)];
+    float4 br=gSrc[clamp(a+int2(1,1),int2(0,0),hi)];
+    gDst[id.xy]=lerp(lerp(tl,tr,f.x),lerp(bl,br,f.x),f.y);
+}
+)hlsl";
+
+// Mild unsharp filter, constrained to the neighbourhood's channel range.
+// No new extrema/overshoot, unchanged alpha and exactly unchanged flat areas.
+static const char kSharpenHlsl[] = R"hlsl(
+Texture2D<float4> gSrc : register(t0);
+RWTexture2D<float4> gDst : register(u0);
+cbuffer Sizes : register(b0) { uint gW; uint gH; uint unusedW; uint unusedH; };
+[numthreads(8,8,1)]
+void CSMain(uint3 id : SV_DispatchThreadID) {
+    if(id.x>=gW || id.y>=gH) return;
+    int2 p=int2(id.xy), hi=int2(gW-1,gH-1);
+    float4 c=gSrc[p];
+    float3 n=gSrc[clamp(p+int2(0,-1),int2(0,0),hi)].rgb;
+    float3 s=gSrc[clamp(p+int2(0,1),int2(0,0),hi)].rgb;
+    float3 e=gSrc[clamp(p+int2(1,0),int2(0,0),hi)].rgb;
+    float3 w=gSrc[clamp(p+int2(-1,0),int2(0,0),hi)].rgb;
+    float3 low=min(c.rgb,min(min(n,s),min(e,w)));
+    float3 high=max(c.rgb,max(max(n,s),max(e,w)));
+    float3 detail=c.rgb-(n+s+e+w)*.25;
+    gDst[p]=float4(clamp(c.rgb+.3*detail,low,high),c.a);
+}
+)hlsl";

--- a/native/super_resolution.inl
+++ b/native/super_resolution.inl
@@ -1,0 +1,229 @@
+// Experimental SR on desktop captures: flat depth, estimated motion, no fabricated jitter.
+static struct SrState {
+    HMODULE module = nullptr;
+    PFN_NR_Create create = nullptr;
+    PFN_NR_Evaluate evaluate = nullptr;
+    PFN_NR_Release release = nullptr;
+    NVSDK_NGX_Parameter *params = nullptr;
+    NVSDK_NGX_Handle *feature = nullptr;
+    VideoTex depth;
+    winrt::com_ptr<ID3D12Resource> raw, nr_in, nr_out, input, motion, output;
+    winrt::com_ptr<ID3D12DescriptorHeap> heap;
+    unsigned scale = 65;
+    UINT w = 0, height = 0, ow = 0, oh = 0;
+    UINT nw = 0, nh = 0;
+    bool initialized = false, failed = false, history = false;
+    int ui = -1;
+} g_sr;
+
+static void CloseSrResources()
+{
+    // Shared scaler caches must not retain descriptors for released textures;
+    // a later allocation can reuse the same COM pointer with a different size.
+    g_scale4_src_bound = g_scale4_dst_bound = nullptr;
+    g_scale4_src_bound2 = g_scale4_dst_bound2 = nullptr;
+    g_res_native_bound = g_res_in_bound = g_res_out_bound = g_res_dst_bound = nullptr;
+    if (g_sr.feature) { g_sr.release(g_sr.feature); g_sr.feature = nullptr; }
+    if (g_sr.depth.tex) { g_sr.depth.tex->Release(); g_sr.depth.tex = nullptr; }
+    if (g_sr.depth.upload) { g_sr.depth.upload->Release(); g_sr.depth.upload = nullptr; }
+    g_sr.input = nullptr; g_sr.motion = nullptr; g_sr.output = nullptr; g_sr.heap = nullptr;
+    g_sr.raw = nullptr; g_sr.nr_in = nullptr; g_sr.nr_out = nullptr;
+    g_sr.history = false;
+}
+
+static bool SrRequested()
+{
+    char value[8] = {};
+    GetEnvironmentVariableA("NS_DLSS_SR", value, sizeof(value));
+    return (g_sr.ui < 0 ? strcmp(value,"1")==0 : g_sr.ui != 0) && !g_sr.failed;
+}
+
+static void ConfigureSrFrame(uint32_t flags)
+{
+    if (!(flags & 0x4000)) return;
+    const int enabled = (flags & 0x2000) != 0;
+    if (g_sr.ui == enabled) return;
+    CloseSrResources();
+    g_sr.ui = enabled; g_sr.failed = false;
+    g_force_next_frame = true;
+    Log("[sr] UI: %s", enabled ? "on" : "off");
+}
+
+static bool EnsureSr(VideoState &v)
+{
+    if (!SrRequested()) { g_sr.history = false; return false; }
+    const UINT ow = v.upscale ? v.full_w : v.w, oh = v.upscale ? v.full_h : v.hgt;
+    UINT sw = std::max(64u, ((ow * g_sr.scale + 100) / 200) * 2);
+    UINT sh = std::max(64u, ((oh * g_sr.scale + 100) / 200) * 2);
+    SafeProcessingSize(ow,oh,sw,sh);
+    // Boost is relative to the already reduced SR input, independently of
+    // the motion grid. No full-size NR/composite is needed on this path.
+    UINT nw = v.nr_small ? std::max(64u, UINT((uint64_t(sw)*v.nr_w + ow)/(2*ow))*2) : sw;
+    UINT nh = v.nr_small ? std::max(64u, UINT((uint64_t(sh)*v.nr_h + oh)/(2*oh))*2) : sh;
+    SafeProcessingSize(sw,sh,nw,nh);
+    if (g_sr.feature && g_sr.w == sw && g_sr.height == sh &&
+        g_sr.ow == ow && g_sr.oh == oh && g_sr.nw == nw && g_sr.nh == nh) return true;
+    CloseSrResources();
+    if (!g_sr.initialized)
+    {
+        wchar_t directory[MAX_PATH] = {}, path[MAX_PATH] = {};
+        GetModuleFileNameW(nullptr, directory, MAX_PATH);
+        if (auto slash = wcsrchr(directory,L'\\')) *(slash+1)=0;
+        wcscpy_s(path,directory);wcscat_s(path,L"nvngx_dlss.dll");
+        if (!g_sr.module) g_sr.module = LoadLibraryW(path);
+        if (!g_sr.module) { Log("[sr] DLL load failed: %lu",GetLastError()); g_sr.failed=true; return false; }
+        auto init = reinterpret_cast<PFN_NR_InitExt>(GetProcAddress(g_sr.module,"NVSDK_NGX_D3D12_Init_Ext"));
+        g_sr.create = reinterpret_cast<PFN_NR_Create>(GetProcAddress(g_sr.module,"NVSDK_NGX_D3D12_CreateFeature"));
+        g_sr.evaluate = reinterpret_cast<PFN_NR_Evaluate>(GetProcAddress(g_sr.module,"NVSDK_NGX_D3D12_EvaluateFeature"));
+        g_sr.release = reinterpret_cast<PFN_NR_Release>(GetProcAddress(g_sr.module,"NVSDK_NGX_D3D12_ReleaseFeature"));
+        if (!init || !g_sr.create || !g_sr.evaluate || !g_sr.release ||
+            (!g_sr.params && NVSDK_NGX_FAILED(NVSDK_NGX_D3D12_AllocateParameters(&g_sr.params))))
+        { Log("[sr] API unavailable; keeping NR output"); g_sr.failed=true; return false; }
+        auto result=init(0x1000000ULL,directory,h.dev,NVSDK_NGX_Version_API,g_sr.params);
+        Log("[sr] Init_Ext -> 0x%08X",result);
+        if (NVSDK_NGX_FAILED(result)) { g_sr.failed=true; return false; }
+        g_sr.initialized=true;
+    }
+    auto p=g_sr.params;p->Reset();
+    p->Set(NVSDK_NGX_Parameter_CreationNodeMask,1u);
+    p->Set(NVSDK_NGX_Parameter_VisibilityNodeMask,1u);
+    p->Set(NVSDK_NGX_Parameter_Width,sw);p->Set(NVSDK_NGX_Parameter_Height,sh);
+    p->Set(NVSDK_NGX_Parameter_OutWidth,ow);p->Set(NVSDK_NGX_Parameter_OutHeight,oh);
+    const float ratio=float(sw)/ow;
+    p->Set(NVSDK_NGX_Parameter_PerfQualityValue,int(ratio>=1.f ? NVSDK_NGX_PerfQuality_Value_DLAA : ratio>=.58f ? NVSDK_NGX_PerfQuality_Value_MaxQuality :
+        ratio>=.5f ? NVSDK_NGX_PerfQuality_Value_Balanced : NVSDK_NGX_PerfQuality_Value_MaxPerf));
+    p->Set(NVSDK_NGX_Parameter_DLSS_Feature_Create_Flags,
+        int(NVSDK_NGX_DLSS_Feature_Flags_MVLowRes | NVSDK_NGX_DLSS_Feature_Flags_AutoExposure));
+    if (!BeginCommands()) { g_sr.failed=true;return false; }
+    auto result=g_sr.create(h.list,NVSDK_NGX_Feature_SuperSampling,p,&g_sr.feature);
+    if (!WaitFenceValue(h.fence,EndCommands(),30000) || NVSDK_NGX_FAILED(result) || !g_sr.feature)
+    { Log("[sr] CreateFeature failed 0x%08X; keeping NR output",result);g_sr.failed=true;CloseSrResources();return false; }
+    if (!CreateVideoTex(g_sr.depth,sw,sh,DXGI_FORMAT_R32_FLOAT,sw*4))
+    { g_sr.failed=true;CloseSrResources();return false; }
+    std::vector<float> depth(size_t(sw)*sh,.5f);
+    if (!FillUpload(g_sr.depth,reinterpret_cast<BYTE*>(depth.data()),sw*4,sh) || !BeginCommands())
+    { g_sr.failed=true;CloseSrResources();return false; }
+    CopyUpload(h.list,g_sr.depth);
+    auto b=Transition(g_sr.depth.tex,D3D12_RESOURCE_STATE_COPY_DEST,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    h.list->ResourceBarrier(1,&b);
+    if (!WaitFenceValue(h.fence,EndCommands(),30000)) { g_sr.failed=true;CloseSrResources();return false; }
+    if (!EnsureScalePipeline()) { g_sr.failed=true;CloseSrResources();return false; }
+    g_sr.input.attach(MakeTex(sw,sh,DXGI_FORMAT_R8G8B8A8_UNORM,true));
+    g_sr.raw.attach(MakeTex(sw,sh,DXGI_FORMAT_R8G8B8A8_UNORM,true));
+    g_sr.nr_in.attach(MakeTex(nw,nh,DXGI_FORMAT_R8G8B8A8_UNORM,true));
+    g_sr.nr_out.attach(MakeTex(nw,nh,DXGI_FORMAT_R8G8B8A8_UNORM,true));
+    g_sr.motion.attach(MakeTex(sw,sh,DXGI_FORMAT_R16G16_FLOAT,true));
+    g_sr.output.attach(MakeTex(ow,oh,DXGI_FORMAT_R8G8B8A8_UNORM,true));
+    D3D12_DESCRIPTOR_HEAP_DESC hd = {};
+    hd.Type=D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;hd.NumDescriptors=8;hd.Flags=D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+    if (!g_sr.raw || !g_sr.nr_in || !g_sr.nr_out || !g_sr.input || !g_sr.motion || !g_sr.output || FAILED(h.dev->CreateDescriptorHeap(&hd,IID_PPV_ARGS(g_sr.heap.put()))) || !BeginCommands())
+    { g_sr.failed=true;CloseSrResources();return false; }
+    D3D12_RESOURCE_BARRIER init[] = {
+        Transition(g_sr.raw.get(),D3D12_RESOURCE_STATE_COMMON,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE),
+        Transition(g_sr.nr_in.get(),D3D12_RESOURCE_STATE_COMMON,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE),
+        Transition(g_sr.nr_out.get(),D3D12_RESOURCE_STATE_COMMON,D3D12_RESOURCE_STATE_UNORDERED_ACCESS),
+        Transition(g_sr.input.get(),D3D12_RESOURCE_STATE_COMMON,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE),
+        Transition(g_sr.motion.get(),D3D12_RESOURCE_STATE_COMMON,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE),
+        Transition(g_sr.output.get(),D3D12_RESOURCE_STATE_COMMON,D3D12_RESOURCE_STATE_UNORDERED_ACCESS)};
+    h.list->ResourceBarrier(6,init);
+    if (!WaitFenceValue(h.fence,EndCommands(),30000)) { g_sr.failed=true;CloseSrResources();return false; }
+    auto cpu=g_sr.heap->GetCPUDescriptorHandleForHeapStart();
+    const UINT stride=h.dev->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    ID3D12Resource *sources[]={v.color.tex,v.mv.tex,g_sr.input.get(),g_sr.output.get()};
+    ID3D12Resource *destinations[]={g_sr.raw.get(),g_sr.motion.get(),v.output,v.output};
+    for (unsigned i=0;i<4;++i) {
+        D3D12_SHADER_RESOURCE_VIEW_DESC srv={};srv.Format=sources[i]->GetDesc().Format;
+        srv.ViewDimension=D3D12_SRV_DIMENSION_TEXTURE2D;srv.Shader4ComponentMapping=D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;srv.Texture2D.MipLevels=1;
+        h.dev->CreateShaderResourceView(sources[i],&srv,cpu);cpu.ptr+=stride;
+        D3D12_UNORDERED_ACCESS_VIEW_DESC uav={};uav.Format=destinations[i]->GetDesc().Format;uav.ViewDimension=D3D12_UAV_DIMENSION_TEXTURE2D;
+        h.dev->CreateUnorderedAccessView(destinations[i],nullptr,&uav,cpu);cpu.ptr+=stride;
+    }
+    g_sr.w=sw;g_sr.height=sh;g_sr.ow=ow;g_sr.oh=oh;
+    g_sr.nw=nw;g_sr.nh=nh;
+    Log("[sr] ready: capture %ux%u -> reduced %ux%u -> NR %ux%u -> SR input %ux%u -> %ux%u",
+        ow,oh,sw,sh,nw,nh,sw,sh,ow,oh);
+    return true;
+}
+
+static void SrScale(unsigned pair, UINT sw, UINT sh, UINT dw, UINT dh, bool motion=false)
+{
+    auto heap=g_sr.heap.get();h.list->SetDescriptorHeaps(1,&heap);
+    h.list->SetComputeRootSignature(g_scale_rs);
+    h.list->SetPipelineState(motion ? g_scale_pso : g_scale4_pso);
+    const UINT sizes[]={dw,dh,sw,sh};
+    h.list->SetComputeRoot32BitConstants(0,4,sizes,0);
+    auto gpu=g_sr.heap->GetGPUDescriptorHandleForHeapStart();
+    gpu.ptr+=UINT64(pair)*2*h.dev->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    h.list->SetComputeRootDescriptorTable(1,gpu);h.list->Dispatch((dw+7)/8,(dh+7)/8,1);
+}
+
+static void PrepareSrInput(VideoState &v)
+{
+    D3D12_RESOURCE_BARRIER pre[]={
+        Transition(g_sr.raw.get(),D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_UNORDERED_ACCESS),
+        Transition(g_sr.motion.get(),D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_UNORDERED_ACCESS)};
+    h.list->ResourceBarrier(2,pre);
+    SrScale(0,g_sr.ow,g_sr.oh,g_sr.w,g_sr.height);
+    SrScale(1,v.w,v.hgt,g_sr.w,g_sr.height,true);
+    D3D12_RESOURCE_BARRIER post[]={
+        Transition(g_sr.raw.get(),D3D12_RESOURCE_STATE_UNORDERED_ACCESS,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE),
+        Transition(g_sr.nr_in.get(),D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_UNORDERED_ACCESS),
+        Transition(g_sr.motion.get(),D3D12_RESOURCE_STATE_UNORDERED_ACCESS,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE)};
+    h.list->ResourceBarrier(3,post);
+    ScaleColorInto(g_sr.raw.get(),g_sr.w,g_sr.height,g_sr.nr_in.get(),g_sr.nw,g_sr.nh,0);
+    auto ready=Transition(g_sr.nr_in.get(),D3D12_RESOURCE_STATE_UNORDERED_ACCESS,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    h.list->ResourceBarrier(1,&ready);
+}
+
+static void ComposeSrInput(VideoState &v)
+{
+    D3D12_RESOURCE_BARRIER before[]={
+        Transition(g_sr.nr_out.get(),D3D12_RESOURCE_STATE_UNORDERED_ACCESS,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE),
+        Transition(g_sr.input.get(),D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_UNORDERED_ACCESS)};
+    h.list->ResourceBarrier(2,before);
+    if (v.nr_small && v.residual)
+        ResidualCompose(g_sr.raw.get(),g_sr.nr_in.get(),g_sr.nr_out.get(),g_sr.w,g_sr.height,g_sr.input.get(),v.residual_strength);
+    else
+        ScaleColorInto(g_sr.nr_out.get(),g_sr.nw,g_sr.nh,g_sr.input.get(),g_sr.w,g_sr.height,1);
+    D3D12_RESOURCE_BARRIER after[]={
+        Transition(g_sr.nr_out.get(),D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_UNORDERED_ACCESS),
+        Transition(g_sr.input.get(),D3D12_RESOURCE_STATE_UNORDERED_ACCESS,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE)};
+    h.list->ResourceBarrier(2,after);
+}
+
+// Only the final reconstruction follows NR; the input reduction precedes it.
+static bool EvaluateSr(VideoState &v, int reset)
+{
+    auto p=g_sr.params;p->Reset();
+    p->Set(NVSDK_NGX_Parameter_Color,g_sr.input.get());p->Set(NVSDK_NGX_Parameter_Output,g_sr.output.get());
+    p->Set(NVSDK_NGX_Parameter_Depth,g_sr.depth.tex);p->Set(NVSDK_NGX_Parameter_MotionVectors,g_sr.motion.get());
+    p->Set(NVSDK_NGX_Parameter_Reset,int(reset || !g_sr.history));
+    p->Set(NVSDK_NGX_Parameter_Jitter_Offset_X,0.f);p->Set(NVSDK_NGX_Parameter_Jitter_Offset_Y,0.f);
+    p->Set(NVSDK_NGX_Parameter_MV_Scale_X,float(g_sr.w)/v.w);p->Set(NVSDK_NGX_Parameter_MV_Scale_Y,float(g_sr.height)/v.hgt);
+    p->Set(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Width,g_sr.w);
+    p->Set(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Height,g_sr.height);
+    p->Set(NVSDK_NGX_Parameter_DLSS_Pre_Exposure,1.f);
+    p->Set(NVSDK_NGX_Parameter_DLSS_Exposure_Scale,1.f);
+    auto result=g_sr.evaluate(h.list,g_sr.feature,p,nullptr);
+    if (NVSDK_NGX_FAILED(result))
+    {
+        Log("[sr] Evaluate failed 0x%08X; scaling reduced NR output",result);
+        g_sr.failed=true;
+        SrScale(2,g_sr.w,g_sr.height,g_sr.ow,g_sr.oh);
+        return false;
+    }
+    auto sharp_pre=Transition(g_sr.output.get(),D3D12_RESOURCE_STATE_UNORDERED_ACCESS,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+    h.list->ResourceBarrier(1,&sharp_pre);
+    auto heap=g_sr.heap.get();h.list->SetDescriptorHeaps(1,&heap);
+    h.list->SetComputeRootSignature(g_scale_rs);h.list->SetPipelineState(g_sharpen_pso);
+    const UINT sizes[]={g_sr.ow,g_sr.oh,g_sr.ow,g_sr.oh};
+    h.list->SetComputeRoot32BitConstants(0,4,sizes,0);
+    auto gpu=g_sr.heap->GetGPUDescriptorHandleForHeapStart();
+    gpu.ptr+=6ull*h.dev->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    h.list->SetComputeRootDescriptorTable(1,gpu);h.list->Dispatch((g_sr.ow+7)/8,(g_sr.oh+7)/8,1);
+    auto sharp_post=Transition(g_sr.output.get(),D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    h.list->ResourceBarrier(1,&sharp_post);
+    if (!g_sr.history) Log("[sr] first evaluation succeeded");
+    g_sr.history=true;
+    return true;
+}

--- a/overlay_ui.py
+++ b/overlay_ui.py
@@ -804,8 +804,10 @@ class OverlayMenu:
                         sr_size = f"{iw}x{ih}"
                 except ValueError:
                     pass
+                if sr_scale >= 1.0:
+                    sr_size += " (DLAA)"
                 slider("dlss_sr_scale", .25, 1.0, sr_scale, s["dlss_sr_input"],
-                       value_text=sr_size, ends=("25%", "100%"))
+                       value_text=sr_size, ends=("25%", "100% (DLAA)"))
 
             # What is being processed - the first question anyone has, and
             # until now the only one answered on another page. The segment

--- a/overlay_ui.py
+++ b/overlay_ui.py
@@ -25,6 +25,7 @@ from typing import Any, Callable
 import pygame
 
 from i18n import STRINGS
+from resolution_limits import safe_processing_size
 
 # --- Themes. The accent is shared; background and text change ------------
 THEMES = {
@@ -174,6 +175,8 @@ class OverlayMenu:
             # main so a config value below the range cannot misplace the knob.
             "work_scale_min": 0.1,
             "nr_small": False,
+            "dlss_sr_scale": .65,
+            "dlss_sr": False,
             "screen_size": "",
             "profile": "",
             "profiles": [],
@@ -735,7 +738,7 @@ class OverlayMenu:
             # the difference is not visible. The residual is what makes that
             # true: without it the same setting is visibly soft.
             boost = bool(self.state.get("nr_small"))
-            toggle("boost", s["boost"], boost, hint=s["boost_hint"])
+            toggle("boost", s["boost"], boost, hint=s["boost_hint"] + "\n" + s["nr_min_hint"])
 
             # The resolution the network runs at - only while Boost is on.
             #
@@ -764,6 +767,19 @@ class OverlayMenu:
                 # screen: NGX is capped at 2560x1440 and the network never
                 # saw more than that (user, 12.09).
                 work = str(self.state.get("work_size") or "")
+                if self.state.get("dlss_sr"):
+                    try:
+                        fw, fh = (int(x) for x in self.state["screen_size"].split("x"))
+                        bw, bh = (int(x) for x in work.split("x")) if work else (int(fw*pos), int(fh*pos))
+                        percent = min(100, max(25, int(float(self.state.get("dlss_sr_scale", .65))*100+.5)))
+                        sw, sh = (max(64, ((size*percent+100)//200)*2) for size in (fw, fh))
+                        sw, sh = safe_processing_size(fw, fh, sw, sh)
+                        nw, nh = (max(64, ((size*boost+full)//(2*full))*2)
+                                  for size, boost, full in ((sw,bw,fw),(sh,bh,fh)))
+                        nw, nh = safe_processing_size(sw, sh, nw, nh)
+                        work = f"{nw}x{nh}"
+                    except (ValueError, KeyError, ZeroDivisionError):
+                        pass
                 value_text = work if work else f"{pos:.2f}"
                 # The lower bound follows WORK_SCALE_MIN (0.1), not a
                 # hardcoded 0.30: a config value below the slider range would
@@ -775,6 +791,21 @@ class OverlayMenu:
                 slider("nr_res", lo, cap, pos, s["nr_res"],
                        value_text=value_text,
                        ends=(s.get("nr_res_low", ""), s.get("nr_res_high", "")))
+
+            sr = bool(self.state.get("dlss_sr"))
+            toggle("dlss_sr", s["dlss_sr"], sr)
+            if sr:
+                sr_scale = float(self.state.get("dlss_sr_scale", .65))
+                sr_size = f"{sr_scale:.0%}"
+                try:
+                    sw, sh = (int(x) for x in str(self.state.get("screen_size", "0x0")).split("x"))
+                    if sw > 0 and sh > 0:
+                        iw, ih = safe_processing_size(sw, sh, max(64, int(sw * sr_scale / 2 + .5) * 2), max(64, int(sh * sr_scale / 2 + .5) * 2))
+                        sr_size = f"{iw}x{ih}"
+                except ValueError:
+                    pass
+                slider("dlss_sr_scale", .25, 1.0, sr_scale, s["dlss_sr_input"],
+                       value_text=sr_size, ends=("25%", "100%"))
 
             # What is being processed - the first question anyone has, and
             # until now the only one answered on another page. The segment
@@ -1317,6 +1348,9 @@ class OverlayMenu:
         if item.key == "split":
             self.state["split"] = value
             return [("split", value)]
+        if item.key == "dlss_sr_scale":
+            self.state["dlss_sr_scale"] = value
+            return [("dlss_sr_scale", value)]
         if item.key == "nr_res":
             # The slider is only on screen while Boost is on, so every
             # position means a work resolution now - there is no "off" step
@@ -1334,6 +1368,7 @@ class OverlayMenu:
                     k = min(2560 / w, 1440 / h)
                     w = max(64, int(round(w * k / 2) * 2))
                     h = max(64, int(round(h * k / 2) * 2))
+                w, h = safe_processing_size(sw, sh, w, h)
                 self.state["work_size"] = f"{w}x{h}"
             except Exception:
                 pass

--- a/pipeline.py
+++ b/pipeline.py
@@ -55,7 +55,7 @@ from winapi import window_frame_rect
 #: Always let through: the pipeline diagnostics. NS_PHASE=1 adds the
 #: per-frame profiler lines ([phase]/[pw]) on top of these.
 _LOG_ALWAYS = ("[host]", "[pure]", "[arch]", "[cap]", "[dda]", "[present]",
-               "[spout]", "[wgc]", "[video]", "[skip]", "[hdr]")
+               "[spout]", "[wgc]", "[video]", "[skip]", "[hdr]", "[sr]")
 #: [video] lines that are a heartbeat rather than a diagnostic: the "delivered
 #: frame N" line is printed every 30 frames and would bury the log.
 _LOG_SKIP = ("delivered frame",)

--- a/protocol.py
+++ b/protocol.py
@@ -27,6 +27,8 @@ import numpy as np
 from paths import BASE_DIR  # noqa: F401
 
 
+
+
 # NGX feature 18 goes silent at 3840x2160 (verified in isolation: the worker
 # hangs on frame 0 with work=4K, both in legacy and in upscale mode).
 # We cap the work resolution at 2560x1440 - that is known to work.
@@ -222,6 +224,9 @@ def _negotiate_shm(worker: subprocess.Popen, reader: "WorkerReader",
 # v3 (magic D5V3): a header with full_w/full_h - the worker resizes the frames
 # on the GPU itself (NGX Upscaling), Python does not resize on the CPU.
 VIDEO_MAGIC = 0x33563544  # 'DV5' v3
+CAPTURE_MAGIC = 0x31504143  # CAP1: prepare capture before calculating motion
+FRAME_FLAG_PREPARED = 0x1000
+
 FRAME_MAGIC = 0x314D5246  # 'FMR1'
 OUT_MAGIC = 0x3154554F    # 'OUT1'
 
@@ -321,12 +326,34 @@ def _read_exact(stream, size: int) -> bytes:
     return bytes(chunks)
 
 
+SR_SCALE_MAGIC = 0x31435353  # SSC1
+
+
+def sync_sr_scale(worker, reader, scale: float) -> None:
+    percent = min(100, max(25, int(round(scale * 100))))
+    if getattr(worker, "_sr_scale_sent", None) == percent:
+        return
+    worker.stdin.write(struct.pack(FRAME_FMT, SR_SCALE_MAGIC, 0, percent, 0, 0))
+    worker.stdin.flush()
+    reader.recv(0, timeout=5.0)
+    worker._sr_scale_sent = percent
+
+
+def prepare_capture(worker, reader, index: int, pts: int) -> None:
+    """Latch capture and gray together; FRM1 will consume that exact capture."""
+    worker.stdin.write(struct.pack(FRAME_FMT, CAPTURE_MAGIC, index, 0, 0, pts))
+    worker.stdin.flush()
+    reader.recv(index, timeout=5.0)
+
+
 def send_frame(worker: subprocess.Popen, index: int, rgba: np.ndarray,
                motion: np.ndarray, reset: bool, pts: int,
                shm: "SharedFrameBuffer | None" = None,
                want_pixels: bool = False, motion_small: bool = False,
                no_color: bool = False, bypass: bool = False,
-               split: float = 0.0, skip_static: bool = False) -> None:
+               split: float = 0.0, skip_static: bool = False,
+               prepared: bool = False,
+               dlss_sr: bool | None = None) -> None:
     """Send a frame to the worker.
 
     With shared memory agreed, only the 24-byte header with the
@@ -350,6 +377,10 @@ def send_frame(worker: subprocess.Popen, index: int, rgba: np.ndarray,
             (FRAME_FLAG_NO_COLOR if no_color else 0) | \
             (FRAME_FLAG_BYPASS if bypass else 0) | \
             (FRAME_FLAG_SKIP_STATIC if skip_static else 0)
+    if dlss_sr is not None:
+        flags |= 0x4000 | (0x2000 if dlss_sr else 0)
+    if prepared:
+        flags |= FRAME_FLAG_PREPARED
     if split > 0.0:
         # The wipe position rides in the high 16 bits of the same flags field:
         # there is no dedicated field in the header, and widening it for a

--- a/resolution_limits.py
+++ b/resolution_limits.py
@@ -1,0 +1,16 @@
+"""Conservative processing floor; shared by sizing and its menu preview."""
+import math
+
+MIN_NR_WIDTH = 256
+MIN_NR_HEIGHT = 144
+
+
+def safe_processing_size(source_w, source_h, width, height):
+    """Raise tiny downscales while keeping the source aspect and source bounds."""
+    mw, mh = min(MIN_NR_WIDTH, source_w), min(MIN_NR_HEIGHT, source_h)
+    if width >= mw and height >= mh:
+        return width, height
+    scale = min(1., max(mw / source_w, mh / source_h,
+                       width / source_w, height / source_h))
+    return (min(source_w, math.ceil(source_w * scale / 2) * 2),
+            min(source_h, math.ceil(source_h * scale / 2) * 2))

--- a/settings_io.py
+++ b/settings_io.py
@@ -24,6 +24,9 @@ from i18n import STRINGS as UI_STRINGS
 # numbers size the shared motion buffer in the SHMI handshake.
 from protocol import WORK_MAX_H, WORK_MAX_W  # noqa: F401
 from winapi import list_capturable_windows
+from resolution_limits import safe_processing_size
+
+
 
 
 def _work_size(width: int, height: int, scale: float) -> tuple[int, int]:
@@ -46,6 +49,7 @@ def _work_size(width: int, height: int, scale: float) -> tuple[int, int]:
     else:
         w = max(64, int(width * scale) // 2 * 2)
         h = max(64, int(height * scale) // 2 * 2)
+    w, h = safe_processing_size(int(width), int(height), min(w, int(width)), min(h, int(height)))
     if w > WORK_MAX_W or h > WORK_MAX_H:
         k = min(WORK_MAX_W / w, WORK_MAX_H / h)
         w = max(64, int(w * k) // 2 * 2)
@@ -254,6 +258,12 @@ def load_config(path: Path) -> dict:
     if lang not in UI_STRINGS:
         lang = DEFAULT_LANG
     cfg["lang"] = lang
+    try:
+        sr_scale = float(cfg.get("dlss_sr_scale", .65))
+    except (TypeError, ValueError):
+        sr_scale = .65
+    cfg["dlss_sr_scale"] = min(1.0, max(.25, sr_scale))
+    cfg["dlss_sr"] = bool(cfg.get("dlss_sr", False))
     return cfg
 
 
@@ -369,6 +379,8 @@ def _menu_layout_payload(cfg: dict, params: dict, monitor: int, lang: str,
         # idles instead of re-running on the same picture. A per-frame flag,
         # so it survives a restart through the config alone.
         "skip_static": bool(cfg.get("skip_static", True)),
+        "dlss_sr_scale": float(cfg.get("dlss_sr_scale", .65)),
+        "dlss_sr": bool(cfg.get("dlss_sr", False)),
         # The user's saved presets. Without this key "Save preset" wrote
         # everything EXCEPT the preset: the menu said "Preset saved", the
         # save really did succeed, and the preset was gone on the next
@@ -449,6 +461,20 @@ def refresh_gpu_ok(st) -> None:
             st.display.alert(UI_STRINGS[st.lang].get(
                 "gpu_nr_fail",
                 "This GPU cannot run the neural pass - the picture stays unprocessed"))
+
+
+def refresh_sr(st) -> None:
+    """Report actual SR failure and reflect the active fallback in the checkbox."""
+    if not st.cfg.get("dlss_sr", False):
+        return
+    for line in reversed(st.worker_logs):
+        if "[sr]" not in line:
+            continue
+        if "failed" in line or "unavailable" in line:
+            st.cfg["dlss_sr"] = False
+            save_menu_layout(st)
+            st.display.alert(UI_STRINGS[st.lang]["dlss_sr_failed"], duration=6.0)
+        return
 
 
 def warn_hdr(st) -> None:
@@ -573,6 +599,8 @@ def menu_payload(st) -> dict:
         "spout": bool(st.cfg.get("spout", False)),
         "hdr": bool(st.cfg.get("hdr", False)),
         "skip_static": bool(st.cfg.get("skip_static", True)),
+        "dlss_sr_scale": float(st.cfg.get("dlss_sr_scale", .65)),
+        "dlss_sr": bool(st.cfg.get("dlss_sr", False)),
         # Is the network idling on an unchanged screen right now? The
         # worker says so in its log; without this the menu shows a
         # healthy FPS while nothing is being processed, and the skip

--- a/tests/quality_gpu.cpp
+++ b/tests/quality_gpu.cpp
@@ -1,0 +1,56 @@
+// Reuse the WARP shader/readback harness; exercise production quality shaders.
+#define main hdr_tests_main
+#include "hdr_gpu.cpp"
+#undef main
+#include "../native/quality_shaders.h"
+#include <algorithm>
+
+int main() {
+    try {
+        D3D_FEATURE_LEVEL fl=D3D_FEATURE_LEVEL_11_0;
+        hr(D3D11CreateDevice(nullptr,D3D_DRIVER_TYPE_WARP,nullptr,0,&fl,1,D3D11_SDK_VERSION,&dev,nullptr,&ctx));
+        std::vector<Pixel> pixels(W*H);
+        for(UINT y=0;y<H;++y) for(UINT x=0;x<W;++x) {
+            float c=((x+2*y)%3)==0 ? 1.f : 0.f;
+            pixels[y*W+x]={c,.2f,.7f,.45f};
+        }
+        auto src=texture(DXGI_FORMAT_R32G32B32A32_FLOAT,pixels.data(),16);
+        auto dst=texture(DXGI_FORMAT_R32G32B32A32_FLOAT,nullptr,16,true);
+        // Fractional footprint 17x9 -> 5x3; verify exact area coverage on GPU.
+        UINT dims[]={5,3,W,H};
+        dispatch(kScaleHlsl4,{src.Get()},dst.Get(),dims);
+        auto bytes=read(dst.Get(),16);auto out=reinterpret_cast<const Pixel*>(bytes.data());
+        for(UINT y=0;y<3;++y) for(UINT x=0;x<5;++x) {
+            double lo=x*double(W)/5, end=(x+1)*double(W)/5, expected=0;
+            for(UINT yy=y*3;yy<(y+1)*3;++yy) for(UINT xx=0;xx<W;++xx)
+                expected+=pixels[yy*W+xx][0]*std::max(0.,std::min(end,double(xx+1))-std::max(lo,double(xx)));
+            expected/=(end-lo)*3;
+            check(std::abs(out[y*W+x][0]-expected)<1e-5,"area coverage mismatch");
+            check(std::abs(out[y*W+x][3]-.45f)<1e-5,"area changed flat alpha");
+        }
+        // 1:1 path must be identity.
+        dims[0]=W;dims[1]=H;
+        dispatch(kScaleHlsl4,{src.Get()},dst.Get(),dims);
+        bytes=read(dst.Get(),16);out=reinterpret_cast<const Pixel*>(bytes.data());
+        for(UINT i=0;i<W*H;++i) for(UINT c=0;c<4;++c)
+            check(std::abs(out[i][c]-pixels[i][c])<1e-6,"1:1 scaling changed pixels");
+        // A softened edge: sharpening must increase contrast without new extrema.
+        for(UINT y=0;y<H;++y) for(UINT x=0;x<W;++x) {
+            float v=x<6 ? .2f : x==6 ? .3f : x==7 ? .7f : .8f;
+            pixels[y*W+x]={v,v,v,.45f};
+        }
+        src=texture(DXGI_FORMAT_R32G32B32A32_FLOAT,pixels.data(),16);
+        dispatch(kSharpenHlsl,{src.Get()},dst.Get(),dims);
+        bytes=read(dst.Get(),16);out=reinterpret_cast<const Pixel*>(bytes.data());
+        for(UINT y=0;y<H;++y) for(UINT x=0;x<W;++x) {
+            float low=pixels[y*W+x][0],high=low;
+            for(int dx=-1;dx<=1;++dx) { float v=pixels[y*W+std::clamp(int(x)+dx,0,int(W)-1)][0];low=std::min(low,v);high=std::max(high,v); }
+            check(out[y*W+x][0]>=low-1e-6 && out[y*W+x][0]<=high+1e-6,"sharpening overshoot");
+            check(out[y*W+x][3]==.45f,"sharpening changed alpha");
+        }
+        check(out[7][0]-out[6][0]>.4f,"soft edge was not sharpened");
+        check(out[0][0]==.2f && out[W-1][0]==.8f,"flat area changed");
+        puts("PASS: GPU area reduction, 1:1 identity, sharper edges, bounded output and alpha");
+        return 0;
+    } catch(const std::exception &e) { fprintf(stderr,"FAIL: %s\n",e.what());return 1; }
+}

--- a/tests/test_motion_floor.py
+++ b/tests/test_motion_floor.py
@@ -1,0 +1,32 @@
+"""A slow scroll must survive the noise filter at every working resolution."""
+from pathlib import Path
+import sys
+from unittest.mock import Mock
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from guides import TemporalGuideGenerator
+
+
+def main():
+    for width, height in ((640, 360), (2560, 1440), (1440, 2560)):
+        guide = TemporalGuideGenerator(width, height, emit_small=True)
+        shape = (guide.flow_height, guide.flow_width)
+        flow = np.zeros((*shape, 2), np.float32)
+        # One real pixel of horizontal motion; 0.1 pixel vertical noise elsewhere.
+        flow[:, :shape[1] // 2, 0] = guide.flow_width / width
+        flow[:, shape[1] // 2:, 1] = .1 * guide.flow_height / height
+        guide.dis = Mock()
+        guide.dis.calc.return_value = flow
+        guide.process(gray=np.full(shape, 100, np.uint8))
+        result = guide.process(gray=np.full(shape, 103, np.uint8))
+        assert not result.reset
+        assert np.allclose(result.motion[:, :shape[1] // 2, 0], 1)
+        assert not np.any(result.motion[:, shape[1] // 2:])
+        static = guide.process(gray=np.full(shape, 103, np.uint8))
+        assert not np.any(static.motion)
+    print('PASS: one-pixel scrolling preserved; subpixel noise and static motion rejected')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_mv_validation.py
+++ b/tests/test_mv_validation.py
@@ -60,9 +60,13 @@ def main() -> int:
     if mag.max() < 1.0:
         failures.append(f"a 4 px shift was zeroed: max {mag.max():.3f}")
 
-    # 3. A sub-floor shift (0.2 px in flow space): zeroed.
+    # 3. A sub-floor shift in WORK pixels, independent of the flow grid.
     g3 = TemporalGuideGenerator(W, H, flow_width=FW, emit_small=True)
     g3.process(_frame(0))
+    from types import SimpleNamespace
+    noise = np.zeros((FH, FW, 2), np.float32)
+    noise[..., 0] = .1 * FW / W
+    g3.dis = SimpleNamespace(calc=lambda *_: noise)
     out3 = g3.process(_frame(1))  # 1 px at 1280 wide = 0.25 px in flow space
     mag3 = np.hypot(out3.motion[..., 0], out3.motion[..., 1])
     if mag3.max() > 0.5:

--- a/tests/test_prepared_capture.py
+++ b/tests/test_prepared_capture.py
@@ -1,0 +1,69 @@
+﻿"""Opt-in GPU regression: a prepared capture must survive source redraws."""
+import ctypes
+import os
+from pathlib import Path
+import struct
+import subprocess
+import sys
+import threading
+import time
+ROOT=Path(__file__).resolve().parents[1]
+sys.path.insert(0,str(ROOT))
+import numpy as np
+import protocol as wire
+
+def exact(pipe,n):
+    data=bytearray()
+    while len(data)<n:
+        part=pipe.read(n-len(data))
+        if not part: raise RuntimeError('worker exited')
+        data.extend(part)
+    return data
+
+def run():
+    ctypes.windll.user32.SetProcessDpiAwarenessContext(ctypes.c_void_p(-4))
+    import pygame
+    pygame.init()
+    w,h=640,360
+    screen=pygame.display.set_mode((w,h),pygame.NOFRAME)
+    screen.fill((210,40,20)); pygame.display.flip()
+    hwnd=pygame.display.get_wm_info()['window']
+    p=subprocess.Popen([str(ROOT/'native/nvngx.dll'),'--live'],cwd=ROOT/'native',
+        env=dict(os.environ,NS_HDR='0',NS_FRAMEGEN='0'),stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,stderr=subprocess.PIPE,creationflags=subprocess.CREATE_NO_WINDOW)
+    logs=[]
+    thread=threading.Thread(target=lambda:logs.extend(iter(p.stderr.readline,b'')),daemon=True);thread.start()
+    watchdog=threading.Timer(30,p.kill);watchdog.start()
+    def ack(fmt): return struct.unpack(fmt,exact(p.stdout,struct.calcsize(fmt)))
+    def capture(index):
+        p.stdin.write(struct.pack(wire.FRAME_FMT,wire.CAPTURE_MAGIC,index,0,0,index));p.stdin.flush()
+        assert ack(wire.OUT_FMT)[2]==1
+    def consume(index):
+        wire.send_frame(p,index,None,np.zeros((h,w,2),np.float16),True,index,
+            no_color=True,bypass=True,want_pixels=True,prepared=True)
+        a=ack(wire.OUT_FMT);assert a[2]==1 and a[3]==w*h*4,a
+        return np.frombuffer(exact(p.stdout,a[3]),np.uint8).reshape(h,w,4)
+    try:
+        p.stdin.write(struct.pack(wire.HEADER_FMT,wire.VIDEO_MAGIC,w,h,1,0,0,0,1,0,0,1.,1.,1.,-1.,w,h));p.stdin.flush()
+        wire.send_wgc(p,hwnd);assert ack(wire.WGC_ACK_FMT)[1]==1
+        time.sleep(.1)
+        capture(0)
+        screen.fill((20,40,210));pygame.display.flip();time.sleep(.1)
+        red=consume(0)[80:280,80:560,:3].mean((0,1))
+        capture(1)
+        blue=consume(1)[80:280,80:560,:3].mean((0,1))
+        assert red[0]>150 and red[2]<70,red
+        assert blue[2]>150 and blue[0]<70,blue
+        # A capture cannot be consumed twice or under a different ID.
+        wire.send_frame(p,2,None,np.zeros((h,w,2),np.float16),True,2,no_color=True,prepared=True)
+        p.stdin.close();p.wait(timeout=10)
+        assert p.returncode==10,p.returncode
+        print('PASS: exact capture retained across redraw; next capture updates; stale ID rejected')
+    finally:
+        if p.poll() is None: p.kill();p.wait()
+        watchdog.cancel();thread.join(timeout=3);pygame.quit()
+    assert b'prepared frame ID mismatch' in b''.join(logs)
+
+if __name__=='__main__':
+    if '--run' in sys.argv:run()
+    else:print('SKIP: use --run for Windows GPU capture test')

--- a/tests/test_quality_gpu.py
+++ b/tests/test_quality_gpu.py
@@ -1,0 +1,30 @@
+"""Compile and run the production scaling/sharpening shader regression on WARP."""
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run():
+    vswhere = Path(os.environ.get('ProgramFiles(x86)', r'C:\Program Files (x86)')) / 'Microsoft Visual Studio/Installer/vswhere.exe'
+    install = subprocess.check_output([str(vswhere), '-latest', '-products', '*',
+        '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+        '-property', 'installationPath'], text=True).strip()
+    if not install:
+        raise RuntimeError('MSVC x64 build tools required for shader tests')
+    vcvars = Path(install) / 'VC/Auxiliary/Build/vcvars64.bat'
+    (ROOT / '_work').mkdir(exist_ok=True)
+    command = (f'"{vcvars}" >nul && cl /nologo /EHsc /std:c++17 tests\\quality_gpu.cpp '
+               '/Fe:_work\\quality_gpu.exe /Fo:_work\\quality_gpu.obj '
+               '/link d3d11.lib d3dcompiler.lib user32.lib')
+    subprocess.run('cmd /d /s /c "' + command + '"', cwd=ROOT, check=True)
+    subprocess.run([str(ROOT / '_work/quality_gpu.exe')], cwd=ROOT, check=True)
+
+
+if __name__ == '__main__':
+    if '--run' in sys.argv:
+        run()
+    else:
+        print('SKIP: use --run for the compiled WARP shader tests')

--- a/tests/test_resolution_limits.py
+++ b/tests/test_resolution_limits.py
@@ -1,0 +1,19 @@
+"""Compounded downscale safety, portrait/odd/small sources and cap precedence."""
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from resolution_limits import safe_processing_size
+from settings_io import _work_size
+
+assert safe_processing_size(640, 360, 64, 64) == (256, 144)
+assert safe_processing_size(960, 540, 240, 136) == (256, 144)
+assert safe_processing_size(480, 270, 240, 136) == (256, 144)
+assert safe_processing_size(640, 360, 320, 180) == (320, 180)
+assert safe_processing_size(100, 80, 64, 64) == (100, 80)
+assert safe_processing_size(539, 901, 64, 64) == (256, 428)
+assert _work_size(2560, 1440, .01) == (256, 144)
+assert _work_size(901, 539, 1) == (901, 539)
+for width, height in ((2560,1440),(3840,2160),(1920,1080),(1080,1920),(100,80),(20000,100)):
+    w,h = _work_size(width,height,.1)
+    assert 0<w<=min(width,2560) and 0<h<=min(height,1440)
+print('PASS: safe combined resolution floor, aspect and bounds')

--- a/tests/test_super_resolution.py
+++ b/tests/test_super_resolution.py
@@ -8,6 +8,7 @@ import threading
 import numpy as np
 ROOT=Path(__file__).resolve().parents[1]
 sys.path.insert(0,str(ROOT))
+sys.path.insert(0,str(Path(__file__).resolve().parent))
 import protocol as wire
 from test_prepared_capture import exact
 

--- a/tests/test_super_resolution.py
+++ b/tests/test_super_resolution.py
@@ -1,0 +1,63 @@
+﻿"""Opt-in SR output, toggle, bypass and resize regression with real NVIDIA DLLs."""
+import os
+from pathlib import Path
+import struct
+import subprocess
+import sys
+import threading
+import numpy as np
+ROOT=Path(__file__).resolve().parents[1]
+sys.path.insert(0,str(ROOT))
+import protocol as wire
+from test_prepared_capture import exact
+
+def run():
+    w,h=640,360;ow,oh=960,540
+    p=subprocess.Popen([str(ROOT/'native/nvngx.dll'),'--live'],cwd=ROOT/'native',
+        env=dict(os.environ,NS_NR_SMALL='1',NS_DLSS_SR='0',NS_FRAMEGEN='0'),
+        stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE,creationflags=subprocess.CREATE_NO_WINDOW)
+    logs=[];thread=threading.Thread(target=lambda:logs.extend(iter(p.stderr.readline,b'')),daemon=True);thread.start()
+    watchdog=threading.Timer(45,p.kill);watchdog.start()
+    def ack(fmt):return struct.unpack(fmt,exact(p.stdout,struct.calcsize(fmt)))
+    try:
+        p.stdin.write(struct.pack(wire.HEADER_FMT,wire.VIDEO_MAGIC,w,h,1,0,0,0,1,0,0,1.,1.,1.,-1.,ow,oh));p.stdin.flush()
+        for i in range(80):
+            if i in (20,25,30,75):
+                scale={20:50,25:25,30:50,75:100}[i]
+                p.stdin.write(struct.pack(wire.FRAME_FMT, wire.SR_SCALE_MAGIC, i, scale, 0, i));p.stdin.flush()
+                assert ack(wire.OUT_FMT)[1:3] == (i, 1)
+            if i in (35,70):
+                w,h=(480,270) if i==35 else (ow,oh)
+                params=dict(profile=0,preset=0,style=0,auto_mask=1,ui_correction=0,intensity=1.,local_tone=1.,local_structure=1.,skin_structure=-1.)
+                wire.send_resize(p,params,w,h,1,ow,oh,nr_small=i!=70)
+                a=ack(wire.RACK_FMT);assert a[1]==1,a
+            frame=np.full((oh,ow,4),(30,90,150,255),np.uint8)
+            frame[100:350,100+i*3:350+i*3,:3]=(210,80,30)
+            motion=np.zeros((h,w,2),np.float16);motion[:,:,0]=-3*w/ow
+            bypass=45<=i<48
+            sr=10<=i<55 or i>=60
+            wire.send_frame(p,i,frame,motion,i in (0,35,48,60),i,bypass=bypass,dlss_sr=sr)
+            a=ack(wire.OUT_FMT);assert a[2]==1 and a[3]==ow*oh*4,a
+            out=np.frombuffer(exact(p.stdout,a[3]),np.uint8).reshape(oh,ow,4)
+            if bypass:assert np.array_equal(out,frame),'SR changed bypass'
+            assert out[:,:,:3].mean()>20,'black output'
+        p.stdin.close();p.wait(timeout=10)
+    finally:
+        if p.poll() is None:p.kill();p.wait()
+        watchdog.cancel();thread.join(timeout=2)
+    log=b''.join(logs).decode('utf-8','replace')
+    print(log)
+    assert p.returncode==0,p.returncode
+    assert log.count('[sr] ready:')==8,log
+    assert 'reduced 480x270 -> NR 320x180 -> SR input 480x270 -> 960x540' in log
+    assert 'reduced 480x270 -> NR 256x144 -> SR input 480x270 -> 960x540' in log
+    assert 'reduced 480x270 -> NR 480x270 -> SR input 480x270 -> 960x540' in log
+    assert 'reduced 960x540 -> NR 960x540 -> SR input 960x540 -> 960x540' in log
+    assert 'input scale: 50% (before NR; Boost ratio unchanged)' in log
+    assert log.count('[sr] first evaluation succeeded')>=4,log
+    assert '[sr] Evaluate failed' not in log and '[sr] CreateFeature failed' not in log
+    print('PASS: reduction before NR, independent Boost ratio, bypass, toggle and resize')
+
+if __name__=='__main__':
+    if '--run' in sys.argv:run()
+    else:print('SKIP: use --run for the NVIDIA GPU test')


### PR DESCRIPTION
Reduce captured frames before neural rendering, then restore the native output size using opt-in DLSS Super Resolution. Boost remains an independent resolution control relative to the reduced input.

Rebased onto current main (v1.8.0). HDR is already upstream in #36; this PR adds SR only, without frame generation, UI detection or network updates.

Includes area reduction, bounded sharpening, minimum processing dimensions, capture/gray pairing before motion estimation, and motion thresholds in working pixels. Disabled by default, with ordinary rendering as the fallback. The SR DLL must be supplied separately.

Validation on the rebased branch: native worker build; RTX 5080 SR reduction-before-NR, independent Boost, bypass, toggle and resize test; resolution floor and motion-floor tests. Fixed the SR test helper import for the bundled portable Python runtime.

Limitations: estimated desktop motion and flat depth are not engine-provided inputs. Image quality and throughput depend on scene and scale; no general FPS improvement is claimed.

At 100% input resolution, DLSS uses DLAA rather than bypassing processing. The slider now labels this explicitly as `100% (DLAA)` and its hint explains the additional GPU cost. UI-control and GPU SR toggle/resize tests pass.
