### PR TITLE
feat: opt-in experimental GPU motion estimation

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -175,6 +175,8 @@ def apply_menu_action(st, action: tuple) -> None:
                 "Autostart ON" if new_state else "Autostart OFF"))
         else:
             st.display.alert(UI_STRINGS[st.lang].get("autostart_err", "Autostart failed"))
+    elif kind == "toggle" and action[1] == "gpu_motion":
+        pipeline.apply_gpu_motion(st, not bool(st.cfg.get("gpu_motion", False)))
     elif kind == "toggle" and action[1] == "rec_indicator":
         # The recording indicator outside the menu: a config flag,
         # the HUD reads it on every redraw.

--- a/docs/GPU_MOTION_EXPERIMENT.md
+++ b/docs/GPU_MOTION_EXPERIMENT.md
@@ -1,104 +1,45 @@
-# GPU motion experiment — 2026-09-13
+# Experimental GPU motion estimation
 
-Outcome: the tested GPU Lucas–Kanade prototype reduces processing time on
-scrolling input, but fails the large-motion quality check. Do not replace DIS
-in the normal application with this prototype.
+This branch is based on upstream v1.8.0 and contains only GPU motion estimation
+and its opt-in control. It requires neither Super Resolution nor Frame Generation.
+No library updater or UI detection is included.
 
-## Scope and setup
+The checkbox defaults off. Switching restarts the worker; off uses CPU DIS.
+On uses a three-level D3D12 Lucas-Kanade flow pyramid and expands the result
+into the neural renderer's motion texture. The worker logs `[gpu-flow]` when
+active. CPU capture paths retain CPU DIS. Gray readback still supplies scene-cut
+and adaptive exposure logic; the ordinary v1.8 capture/protocol order is retained.
+This is not a zero-copy pipeline. No additional NVIDIA library is needed.
 
-- Branch: `experiment/gpu-motion`, based on combined build `76637fc`.
-- RTX 5080, Windows 11, NVIDIA driver 32.0.16.1664; bundled Python 3.11.14.
-- Same experimental worker executable for A and B, selected with
-  `NS_GPU_FLOW_EXPERIMENT=0` / `1`. Default is off.
-- CPU baseline: production OpenCV DIS FAST, four threads, 320x180 grid.
-- GPU candidate: three-level 80x45 -> 160x90 -> 320x180 Lucas–Kanade,
-  six iterations per level, 5x5 windows, bilinear expansion to NR resolution.
-- WGC capture, real NR and GPU presentation at 2560x1440; HDR enabled;
-  SR and UI protection disabled; FG off or 2x.
-- Repeatable synthetic textured scrolling with text. Motion runs use ABBA
-  order, 220 frames per run, first 40 excluded: 360 measured frames per arm
-  per FG setting. Static controls use 180 measured frames per arm.
-- Measured CPU wall time includes CAP1 capture preparation and acknowledgement,
-  gray access/guide generation, frame submission, NR, optional FG and present
-  acknowledgement. Source drawing and the application's Python menu/event loop
-  are not included. These are worker-pipeline timings, not whole-app FPS.
+## Known quality limitation
 
-## Measurements
+The algorithm is an experiment, not a replacement suitable for every scene.
+On an RTX 5080 synthetic translation test, one flow-grid pixel per frame produces
+about 0.0014 median endpoint error. A 15-pixel displacement can fail badly
+(about 15 pixels of error in the original experiment). Fast motion can distort.
+Keep this limitation visible when reviewing or enabling the checkbox.
 
-Mean milliseconds per processed frame:
+Earlier combined-branch tests showed lower processing time on moving content
+and no meaningful static-scene gain. Those numbers do not establish performance
+of this standalone v1.8 branch. The user also reported an FPS improvement in
+the combined preview. No FPS guarantee is made here.
 
-| Input | FG | CPU DIS | GPU LK | Time reduction |
-|---|---|---:|---:|---:|
-| Scrolling, all samples | off | 9.789 | 8.157 | 16.7% |
-| Scrolling, all samples | 2x | 14.049 | 10.796 | 23.2% |
-| Scrolling, changed captures only | off | 11.018 | 8.383 | 23.9% |
-| Scrolling, changed captures only | 2x | 14.514 | 11.109 | 23.5% |
-| Static, forced processing | off | 8.014 | 8.150 | -1.7% |
-| Static, forced processing | 2x | 10.822 | 10.801 | ~0% |
+## Validation and reproduction
 
-WGC delivered duplicate images in some iterations. New/changed captures were
-219/360 vs 188/360 without FG and 306/360 vs 240/360 with FG (CPU vs GPU).
-The all-sample comparison therefore mixes different proportions of static and
-moving frames. The changed-only comparison is included to expose that effect.
-No increase in unique displayed frames per second is established by this test.
-Do not convert inverse processing time into a claimed game FPS improvement.
+- `cmd /c native\build-host.bat`
+- `runtime/python.exe tests/test_gpu_motion_controls.py`
+- `runtime/python.exe tests/experiment_gpu_flow.py --quality`
+- `runtime/python.exe tests/experiment_gpu_flow.py`
 
-The static control deliberately processes repeated captures (`skip_static=False`)
-to measure the added work. It does not model the normal idle application's
-skip-static behavior. CPU DIS already avoids flow on static images.
+The native build, UI on/off/persistence/Russian-text test, and CPU/GPU quality
+runs completed on RTX 5080 on 2026-09-13. Quality runs report errors rather
+than asserting that the known large-motion defect has been fixed.
 
-## Quality gate
-
-A separate 1280x720 run saves GPU flow through readback; dumping is disabled
-for all performance runs. Compare interior vectors against the actual captured
-pair's integer translation, identified by an exhaustive image alignment search.
-Errors below are in 320x180 flow-grid pixels, not display pixels.
-
-| Case | CPU DIS median endpoint error | GPU LK median endpoint error |
-|---|---:|---:|
-| Small motion, median across frames | 0.01350 | 0.00142 |
-| Large 15-pixel translation | 0.01375 | 15.16391 |
-
-The GPU prototype estimates approximately 0.84 pixels instead of 15 on the
-large translation. CPU DIS correctly estimates 15. This is a failed quality
-gate, even though small translations are accurate. No equivalence on game
-occlusions, particles, camera rotation or temporal NR/FG image quality is claimed.
-
-## What remains on CPU
-
-This isolates replacement of DIS; it is not a zero-readback pipeline.
-Gray readback still supplies scene-cut detection, adaptive exposure and optional
-UI detection. The wire still carries a placeholder motion payload for the GPU
-arm. There is still a GPU fence wait at the motion stage. Eliminating those costs
-is a separate experiment. GPU stage-only timestamps were not added here.
-
-The application experiment also times `prepare_capture` separately; it was
-outside the existing per-stage timers. This timing must not be treated as pure
-copy time: capture availability and GPU queue waits are included.
-
-## Reproduce
-
-From the experiment worktree, with no other NeuralScreen instance active:
-
-```powershell
-cmd /c native\build-host.bat
-runtime/python.exe tests/experiment_gpu_flow.py --quality
-runtime/python.exe tests/experiment_gpu_flow.py
-runtime/python.exe tests/experiment_gpu_flow.py --static
-```
-
-Runs briefly display a synthetic source and the worker's overlay, then close
-them. They do not modify personal config. Raw timing rows, flow dumps, worker
-logs and `summary.json` are in `_work/gpu-flow-results/`.
-
-Next useful step: improve robustness to larger displacement (deeper pyramid,
-coarse matching and confidence rejection), then rerun the same A/B timing and
-quality checks. Extra quality work will consume some of the measured savings.
-Main application and published PR branches were not changed by this experiment.
-
-## Interactive preview
-
-Branch `feature/gpu-motion-preview` adds a persisted `gpu_motion` checkbox to
-the main menu. It defaults off. Switching restarts the worker; CPU DIS is used
-when off. Start this worktree through its `NeuralScreen.vbs`. The GPU algorithm
-is unchanged and still fails the large-motion quality gate described above.
+The harness opens a synthetic WGC source and worker presentation window. It
+uses the existing live protocol, without SR/FG or prepared-capture extensions.
+GPU quality comparisons read the gray image after the worker acknowledges the
+frame, matching the dumped flow to its captured image. CPU comparisons use the
+gray pair that CPU DIS actually processed. Timing is host wall-clock time and
+includes capture/queue waits, not pure GPU kernel duration. Raw rows and logs
+are saved under `_work/gpu-flow-results/`. Close the application before running
+GPU benchmarks to avoid contention; the harness leaves personal config alone.

--- a/docs/GPU_MOTION_EXPERIMENT.md
+++ b/docs/GPU_MOTION_EXPERIMENT.md
@@ -43,3 +43,8 @@ gray pair that CPU DIS actually processed. Timing is host wall-clock time and
 includes capture/queue waits, not pure GPU kernel duration. Raw rows and logs
 are saved under `_work/gpu-flow-results/`. Close the application before running
 GPU benchmarks to avoid contention; the harness leaves personal config alone.
+
+Capture sessions without the gray channel retain the supplied CPU motion
+instead of entering the GPU flow path. This fallback was checked using
+`tests/test_hdr_capture.py --run` with `NS_GPU_FLOW_EXPERIMENT=1`: WGC HDR,
+NR, bypass, wipe, SDR export and HDR-to-SDR transition passed (12 frames).

--- a/docs/GPU_MOTION_EXPERIMENT.md
+++ b/docs/GPU_MOTION_EXPERIMENT.md
@@ -1,0 +1,97 @@
+# GPU motion experiment — 2026-09-13
+
+Outcome: the tested GPU Lucas–Kanade prototype reduces processing time on
+scrolling input, but fails the large-motion quality check. Do not replace DIS
+in the normal application with this prototype.
+
+## Scope and setup
+
+- Branch: `experiment/gpu-motion`, based on combined build `76637fc`.
+- RTX 5080, Windows 11, NVIDIA driver 32.0.16.1664; bundled Python 3.11.14.
+- Same experimental worker executable for A and B, selected with
+  `NS_GPU_FLOW_EXPERIMENT=0` / `1`. Default is off.
+- CPU baseline: production OpenCV DIS FAST, four threads, 320x180 grid.
+- GPU candidate: three-level 80x45 -> 160x90 -> 320x180 Lucas–Kanade,
+  six iterations per level, 5x5 windows, bilinear expansion to NR resolution.
+- WGC capture, real NR and GPU presentation at 2560x1440; HDR enabled;
+  SR and UI protection disabled; FG off or 2x.
+- Repeatable synthetic textured scrolling with text. Motion runs use ABBA
+  order, 220 frames per run, first 40 excluded: 360 measured frames per arm
+  per FG setting. Static controls use 180 measured frames per arm.
+- Measured CPU wall time includes CAP1 capture preparation and acknowledgement,
+  gray access/guide generation, frame submission, NR, optional FG and present
+  acknowledgement. Source drawing and the application's Python menu/event loop
+  are not included. These are worker-pipeline timings, not whole-app FPS.
+
+## Measurements
+
+Mean milliseconds per processed frame:
+
+| Input | FG | CPU DIS | GPU LK | Time reduction |
+|---|---|---:|---:|---:|
+| Scrolling, all samples | off | 9.789 | 8.157 | 16.7% |
+| Scrolling, all samples | 2x | 14.049 | 10.796 | 23.2% |
+| Scrolling, changed captures only | off | 11.018 | 8.383 | 23.9% |
+| Scrolling, changed captures only | 2x | 14.514 | 11.109 | 23.5% |
+| Static, forced processing | off | 8.014 | 8.150 | -1.7% |
+| Static, forced processing | 2x | 10.822 | 10.801 | ~0% |
+
+WGC delivered duplicate images in some iterations. New/changed captures were
+219/360 vs 188/360 without FG and 306/360 vs 240/360 with FG (CPU vs GPU).
+The all-sample comparison therefore mixes different proportions of static and
+moving frames. The changed-only comparison is included to expose that effect.
+No increase in unique displayed frames per second is established by this test.
+Do not convert inverse processing time into a claimed game FPS improvement.
+
+The static control deliberately processes repeated captures (`skip_static=False`)
+to measure the added work. It does not model the normal idle application's
+skip-static behavior. CPU DIS already avoids flow on static images.
+
+## Quality gate
+
+A separate 1280x720 run saves GPU flow through readback; dumping is disabled
+for all performance runs. Compare interior vectors against the actual captured
+pair's integer translation, identified by an exhaustive image alignment search.
+Errors below are in 320x180 flow-grid pixels, not display pixels.
+
+| Case | CPU DIS median endpoint error | GPU LK median endpoint error |
+|---|---:|---:|
+| Small motion, median across frames | 0.01350 | 0.00142 |
+| Large 15-pixel translation | 0.01375 | 15.16391 |
+
+The GPU prototype estimates approximately 0.84 pixels instead of 15 on the
+large translation. CPU DIS correctly estimates 15. This is a failed quality
+gate, even though small translations are accurate. No equivalence on game
+occlusions, particles, camera rotation or temporal NR/FG image quality is claimed.
+
+## What remains on CPU
+
+This isolates replacement of DIS; it is not a zero-readback pipeline.
+Gray readback still supplies scene-cut detection, adaptive exposure and optional
+UI detection. The wire still carries a placeholder motion payload for the GPU
+arm. There is still a GPU fence wait at the motion stage. Eliminating those costs
+is a separate experiment. GPU stage-only timestamps were not added here.
+
+The application experiment also times `prepare_capture` separately; it was
+outside the existing per-stage timers. This timing must not be treated as pure
+copy time: capture availability and GPU queue waits are included.
+
+## Reproduce
+
+From the experiment worktree, with no other NeuralScreen instance active:
+
+```powershell
+cmd /c native\build-host.bat
+runtime/python.exe tests/experiment_gpu_flow.py --quality
+runtime/python.exe tests/experiment_gpu_flow.py
+runtime/python.exe tests/experiment_gpu_flow.py --static
+```
+
+Runs briefly display a synthetic source and the worker's overlay, then close
+them. They do not modify personal config. Raw timing rows, flow dumps, worker
+logs and `summary.json` are in `_work/gpu-flow-results/`.
+
+Next useful step: improve robustness to larger displacement (deeper pyramid,
+coarse matching and confidence rejection), then rerun the same A/B timing and
+quality checks. Extra quality work will consume some of the measured savings.
+Main application and published PR branches were not changed by this experiment.

--- a/docs/GPU_MOTION_EXPERIMENT.md
+++ b/docs/GPU_MOTION_EXPERIMENT.md
@@ -95,3 +95,10 @@ Next useful step: improve robustness to larger displacement (deeper pyramid,
 coarse matching and confidence rejection), then rerun the same A/B timing and
 quality checks. Extra quality work will consume some of the measured savings.
 Main application and published PR branches were not changed by this experiment.
+
+## Interactive preview
+
+Branch `feature/gpu-motion-preview` adds a persisted `gpu_motion` checkbox to
+the main menu. It defaults off. Switching restarts the worker; CPU DIS is used
+when off. Start this worktree through its `NeuralScreen.vbs`. The GPU algorithm
+is unchanged and still fails the large-motion quality gate described above.

--- a/guides.py
+++ b/guides.py
@@ -77,7 +77,7 @@ class TemporalGuideGenerator:
         return GuideFrame(motion=motion, reset=True, scene_score=1.0)
 
     def process(self, rgba: np.ndarray | None = None,
-                gray: np.ndarray | None = None) -> GuideFrame:
+                gray: np.ndarray | None = None, compute_motion: bool = True) -> GuideFrame:
         """Compute the guides: motion/reset/scene_score.
 
         Either rgba (full-res BGR/RGBA — downsampled here) or a ready gray
@@ -99,7 +99,7 @@ class TemporalGuideGenerator:
         else:
             scene_score = float(np.mean(cv2.absdiff(current, self.previous_gray))) / 255.0
             reset = scene_score > 0.24
-            if reset or scene_score < 0.001:
+            if not compute_motion or reset or scene_score < 0.001:
                 # Reset (scene cut) or static screen (desktop/text): no flow needed.
                 # 0.001: above capture noise (~0.0002 @ +-2 LSB) and static 0.0,
                 # below real motion: 2px scroll 0.03, 2px shift 0.002, fast cursor 0.0013.

--- a/i18n.py
+++ b/i18n.py
@@ -1555,3 +1555,9 @@ STRINGS = {
 def tr(lang: str, key: str) -> str:
     """Translate a STRINGS key; an unknown key comes back unchanged."""
     return STRINGS.get(lang, STRINGS[DEFAULT_LANG]).get(key, key)
+
+for _table in STRINGS.values():
+    _table["gpu_motion"] = "GPU motion estimation (experimental)"
+    _table["gpu_motion_hint"] = "May distort fast motion. Off: CPU DIS. Switching restarts processing."
+STRINGS["ru"]["gpu_motion"] = "Расчёт движения на GPU (эксперимент)"
+STRINGS["ru"]["gpu_motion_hint"] = "При резком движении возможны искажения.\nВыключено: CPU DIS. Смена режима перезапускает обработку."

--- a/main.py
+++ b/main.py
@@ -575,7 +575,7 @@ def main() -> int:
             try:
                 t0 = time.perf_counter()
                 if st.gray_active:
-                    guide = st.guides.process(gray=st.shm.read_gray())
+                    guide = st.guides.process(gray=st.shm.read_gray(), compute_motion=os.environ.get("NS_GPU_FLOW_EXPERIMENT") != "1")
                 else:
                     guide = st.guides.process(st.work_frame)
                 _perf("guides", t0)

--- a/native/dlss5-feed-host64.cpp
+++ b/native/dlss5-feed-host64.cpp
@@ -4986,7 +4986,8 @@ static int RunVideo()
                 ? SplitXFromFlags(fh.reserved, v.upscale ? v.full_w : v.w) : 0u;
             g_force_next_frame = false;
             const double t_up = PhaseNow();
-            const bool up_ok = GpuMotionExperiment() ? RunGpuMotionExperiment(v, fh.reset != 0) : UploadMotionOnly(v, mv_ptr,
+            const bool up_ok = GpuMotionExperiment() && g_gray_mapped && g_gray_uav
+                ? RunGpuMotionExperiment(v, fh.reset != 0) : UploadMotionOnly(v, mv_ptr,
                                   (fh.reserved & FRAME_FLAG_MOTION_SMALL) != 0 && g_motion_w != 0);
             PhaseAdd(PH_UPLOAD, t_up);
             if (!up_ok) return 6;

--- a/native/dlss5-feed-host64.cpp
+++ b/native/dlss5-feed-host64.cpp
@@ -4029,6 +4029,8 @@ static bool UploadVideoFrame(VideoState &v, const BYTE *color, const BYTE *mv, b
     return WaitFenceValue(h.fence, fence, 30000);
 }
 
+#include "gpu_motion_experiment.inl"
+
 // DDA mode: the colour is already in v.color.tex (DdaGrab), we upload only motion.
 static bool UploadMotionOnly(VideoState &v, const BYTE *mv, bool motion_small)
 {
@@ -4984,7 +4986,7 @@ static int RunVideo()
                 ? SplitXFromFlags(fh.reserved, v.upscale ? v.full_w : v.w) : 0u;
             g_force_next_frame = false;
             const double t_up = PhaseNow();
-            const bool up_ok = UploadMotionOnly(v, mv_ptr,
+            const bool up_ok = GpuMotionExperiment() ? RunGpuMotionExperiment(v, fh.reset != 0) : UploadMotionOnly(v, mv_ptr,
                                   (fh.reserved & FRAME_FLAG_MOTION_SMALL) != 0 && g_motion_w != 0);
             PhaseAdd(PH_UPLOAD, t_up);
             if (!up_ok) return 6;

--- a/native/gpu_motion_experiment.inl
+++ b/native/gpu_motion_experiment.inl
@@ -92,7 +92,7 @@ static void DumpExperimentFlow(ID3D12Resource *texture)
 static bool InitFlowExperiment()
 {
  auto &f=g_flow_exp;
- if(f.rs) return true;
+ if(f.rs) return f.down && f.flow && f.expand && f.heap;
  D3D12_DESCRIPTOR_RANGE ranges[2]={};
  ranges[0]={D3D12_DESCRIPTOR_RANGE_TYPE_SRV,3,0,0,0};
  ranges[1]={D3D12_DESCRIPTOR_RANGE_TYPE_UAV,1,0,0,3};
@@ -125,6 +125,7 @@ static bool InitFlowExperiment()
 static bool RunGpuMotionExperiment(VideoState &v,bool reset)
 {
  if(!g_gray_uav || !InitFlowExperiment()) return false;
+ static bool reported=false; if(!reported) { Log("[gpu-flow] experimental GPU Lucas-Kanade active");reported=true; }
  auto &f=g_flow_exp;
  const bool fresh=f.w!=g_gray_w || f.hgt!=g_gray_h;
  if(fresh) {

--- a/native/gpu_motion_experiment.inl
+++ b/native/gpu_motion_experiment.inl
@@ -1,0 +1,192 @@
+// Isolated experiment. Gray readback stays enabled for exposure/reset detection.
+// Three-level inverse-compositional Lucas-Kanade, current -> previous.
+static bool GpuMotionExperiment()
+{
+    static const bool enabled = [] { char b[8] = {}; GetEnvironmentVariableA("NS_GPU_FLOW_EXPERIMENT", b, 8); return b[0]=='1'; }();
+    return enabled;
+}
+static const char kFlowExperimentShader[] = R"hlsl(
+Texture2D<float2> A : register(t0);
+Texture2D<float2> B : register(t1);
+Texture2D<float2> Coarse : register(t2);
+RWTexture2D<float2> Out : register(u0);
+SamplerState LinearClamp : register(s0);
+cbuffer C : register(b0) { uint W,H,SrcW,SrcH,Factor,Reset,WorkW,WorkH; };
+[numthreads(8,8,1)]
+void Down(uint3 tid:SV_DispatchThreadID) {
+ if(tid.x>=W || tid.y>=H) return;
+ float2 sum=0;
+ for(uint y=0;y<Factor;y++) for(uint x=0;x<Factor;x++) {
+  int2 p=min(int2(tid.xy*Factor+uint2(x,y)),int2(SrcW-1,SrcH-1));
+  sum+=float2(A.Load(int3(p,0)).x,B.Load(int3(p,0)).x);
+ }
+ Out[tid.xy]=sum/(Factor*Factor);
+}
+float2 samplePair(float2 p) { return A.SampleLevel(LinearClamp,(p+0.5)/float2(W,H),0); }
+[numthreads(8,8,1)]
+void Flow(uint3 tid:SV_DispatchThreadID) {
+ if(tid.x>=W || tid.y>=H) return;
+ if(Reset) { Out[tid.xy]=0; return; }
+ float2 uv=(float2(tid.xy)+0.5)/float2(W,H);
+ float2 v=Factor==4 ? float2(0,0) : Coarse.SampleLevel(LinearClamp,uv,0)*2;
+ float gxx=0,gyy=0,gxy=0;
+ for(int y=-2;y<=2;y++) for(int x=-2;x<=2;x++) {
+  float2 p=float2(tid.xy)+float2(x,y);
+  float gx=(samplePair(p+float2(1,0)).x-samplePair(p-float2(1,0)).x)*.5;
+  float gy=(samplePair(p+float2(0,1)).x-samplePair(p-float2(0,1)).x)*.5;
+  gxx+=gx*gx; gyy+=gy*gy; gxy+=gx*gy;
+ }
+ float det=gxx*gyy-gxy*gxy;
+ if(det>1e-8) for(int iter=0;iter<6;iter++) {
+  float2 b=0;
+  for(int y=-2;y<=2;y++) for(int x=-2;x<=2;x++) {
+   float2 p=float2(tid.xy)+float2(x,y);
+   float gx=(samplePair(p+float2(1,0)).x-samplePair(p-float2(1,0)).x)*.5;
+   float gy=(samplePair(p+float2(0,1)).x-samplePair(p-float2(0,1)).x)*.5;
+   float residual=samplePair(p).x-samplePair(p+v).y;
+   b+=float2(gx,gy)*residual;
+  }
+  float2 delta=float2(gyy*b.x-gxy*b.y,gxx*b.y-gxy*b.x)/det;
+  v+=clamp(delta,-1.5,1.5);
+ }
+ Out[tid.xy]=clamp(v,-32,32);
+}
+[numthreads(8,8,1)]
+void Expand(uint3 tid:SV_DispatchThreadID) {
+ if(tid.x>=W || tid.y>=H) return;
+ float2 v=A.SampleLevel(LinearClamp,(float2(tid.xy)+.5)/float2(W,H),0)*float2(W,H)/float2(SrcW,SrcH);
+ Out[tid.xy]=length(v)<.5 ? float2(0,0) : v;
+}
+)hlsl";
+struct FlowExperimentState {
+    winrt::com_ptr<ID3D12RootSignature> rs;
+    winrt::com_ptr<ID3D12PipelineState> down, flow, expand;
+    winrt::com_ptr<ID3D12DescriptorHeap> heap;
+    winrt::com_ptr<ID3D12Resource> previous, pairs[3], vectors[3];
+    UINT w=0,hgt=0; bool valid=false;
+};
+static FlowExperimentState g_flow_exp;
+static void DumpExperimentFlow(ID3D12Resource *texture)
+{
+ char folder[MAX_PATH]={};if(!GetEnvironmentVariableA("NS_FLOW_DUMP",folder,MAX_PATH)) return;
+ auto desc=texture->GetDesc();D3D12_PLACED_SUBRESOURCE_FOOTPRINT fp={};UINT rows;UINT64 rowBytes,total;
+ h.dev->GetCopyableFootprints(&desc,0,1,0,&fp,&rows,&rowBytes,&total);
+ D3D12_HEAP_PROPERTIES hp={};hp.Type=D3D12_HEAP_TYPE_READBACK;
+ D3D12_RESOURCE_DESC rd={};rd.Dimension=D3D12_RESOURCE_DIMENSION_BUFFER;rd.Width=total;rd.Height=1;
+ rd.DepthOrArraySize=rd.MipLevels=1;rd.SampleDesc.Count=1;rd.Layout=D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+ winrt::com_ptr<ID3D12Resource> readback;
+ if(FAILED(h.dev->CreateCommittedResource(&hp,D3D12_HEAP_FLAG_NONE,&rd,D3D12_RESOURCE_STATE_COPY_DEST,nullptr,__uuidof(ID3D12Resource),readback.put_void()))) return;
+ if(!BeginCommands()) return;
+ auto pre=Transition(texture,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_COPY_SOURCE);h.list->ResourceBarrier(1,&pre);
+ D3D12_TEXTURE_COPY_LOCATION src={},dst={};src.pResource=texture;src.Type=D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+ dst.pResource=readback.get();dst.Type=D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;dst.PlacedFootprint=fp;
+ h.list->CopyTextureRegion(&dst,0,0,0,&src,nullptr);
+ auto post=Transition(texture,D3D12_RESOURCE_STATE_COPY_SOURCE,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);h.list->ResourceBarrier(1,&post);
+ if(!WaitFenceValue(h.fence,EndCommands(),30000)) return;
+ void *data=nullptr;D3D12_RANGE rr={0,SIZE_T(total)};
+ if(FAILED(readback->Map(0,&rr,&data))) return;
+ static UINT index=0;char file[MAX_PATH];snprintf(file,sizeof(file),"%s/flow-%04u.bin",folder,index++);
+ FILE *out=fopen(file,"wb");if(out) { for(UINT y=0;y<rows;y++) fwrite((BYTE*)data+fp.Offset+y*fp.Footprint.RowPitch,1,SIZE_T(rowBytes),out);fclose(out); }
+ readback->Unmap(0,nullptr);
+}
+static bool InitFlowExperiment()
+{
+ auto &f=g_flow_exp;
+ if(f.rs) return true;
+ D3D12_DESCRIPTOR_RANGE ranges[2]={};
+ ranges[0]={D3D12_DESCRIPTOR_RANGE_TYPE_SRV,3,0,0,0};
+ ranges[1]={D3D12_DESCRIPTOR_RANGE_TYPE_UAV,1,0,0,3};
+ D3D12_ROOT_PARAMETER roots[2]={};
+ roots[0].ParameterType=D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
+ roots[0].Constants={0,0,8};
+ roots[1].ParameterType=D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+ roots[1].DescriptorTable={2,ranges};
+ D3D12_STATIC_SAMPLER_DESC sampler={};
+ sampler.Filter=D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+ sampler.AddressU=sampler.AddressV=sampler.AddressW=D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+ sampler.MaxLOD=D3D12_FLOAT32_MAX; sampler.ShaderVisibility=D3D12_SHADER_VISIBILITY_ALL;
+ D3D12_ROOT_SIGNATURE_DESC desc={2,roots,1,&sampler,D3D12_ROOT_SIGNATURE_FLAG_NONE};
+ winrt::com_ptr<ID3DBlob> code,errors;
+ if(FAILED(D3D12SerializeRootSignature(&desc,D3D_ROOT_SIGNATURE_VERSION_1,code.put(),errors.put()))) return false;
+ if(FAILED(h.dev->CreateRootSignature(0,code->GetBufferPointer(),code->GetBufferSize(),__uuidof(ID3D12RootSignature),f.rs.put_void()))) return false;
+ const char *names[]={"Down","Flow","Expand"};
+ ID3D12PipelineState **targets[]={f.down.put(),f.flow.put(),f.expand.put()};
+ for(int i=0;i<3;i++) {
+  code=nullptr;errors=nullptr;
+  if(FAILED(D3DCompile(kFlowExperimentShader,sizeof(kFlowExperimentShader)-1,nullptr,nullptr,nullptr,names[i],"cs_5_0",D3DCOMPILE_OPTIMIZATION_LEVEL3,0,code.put(),errors.put()))) {
+   Log("[gpu-flow] compile: %s",errors ? (const char*)errors->GetBufferPointer() : "failed"); return false;
+  }
+  D3D12_COMPUTE_PIPELINE_STATE_DESC pd={};pd.pRootSignature=f.rs.get();pd.CS={code->GetBufferPointer(),code->GetBufferSize()};
+  if(FAILED(h.dev->CreateComputePipelineState(&pd,__uuidof(ID3D12PipelineState),(void**)targets[i]))) return false;
+ }
+ D3D12_DESCRIPTOR_HEAP_DESC hd={D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,28,D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE,0};
+ return SUCCEEDED(h.dev->CreateDescriptorHeap(&hd,__uuidof(ID3D12DescriptorHeap),f.heap.put_void()));
+}
+static bool RunGpuMotionExperiment(VideoState &v,bool reset)
+{
+ if(!g_gray_uav || !InitFlowExperiment()) return false;
+ auto &f=g_flow_exp;
+ const bool fresh=f.w!=g_gray_w || f.hgt!=g_gray_h;
+ if(fresh) {
+  f.w=g_gray_w;f.hgt=g_gray_h;f.valid=false;
+  f.previous.attach(MakeTex(f.w,f.hgt,DXGI_FORMAT_R8_UNORM,false));
+  for(int i=0;i<3;i++) {
+   UINT factor=4u>>i;
+   f.pairs[i].attach(MakeTex((f.w+factor-1)/factor,(f.hgt+factor-1)/factor,DXGI_FORMAT_R16G16_FLOAT,true));
+   f.vectors[i].attach(MakeTex((f.w+factor-1)/factor,(f.hgt+factor-1)/factor,DXGI_FORMAT_R16G16_FLOAT,true));
+   if(!f.pairs[i] || !f.vectors[i]) return false;
+  }
+  if(!f.previous) return false;
+ }
+ if(!BeginCommands()) return false;
+ auto barrier=[](ID3D12Resource *r,D3D12_RESOURCE_STATES a,D3D12_RESOURCE_STATES b) {
+  auto t=Transition(r,a,b);h.list->ResourceBarrier(1,&t);
+ };
+ barrier(g_gray_uav,D3D12_RESOURCE_STATE_UNORDERED_ACCESS,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+ if(!f.valid) {
+  barrier(g_gray_uav,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_COPY_SOURCE);
+  barrier(f.previous.get(),fresh?D3D12_RESOURCE_STATE_COMMON:D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_COPY_DEST);
+  h.list->CopyResource(f.previous.get(),g_gray_uav);
+  barrier(f.previous.get(),D3D12_RESOURCE_STATE_COPY_DEST,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+  barrier(g_gray_uav,D3D12_RESOURCE_STATE_COPY_SOURCE,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+ }
+ ID3D12DescriptorHeap *heaps[]={f.heap.get()};h.list->SetDescriptorHeaps(1,heaps);h.list->SetComputeRootSignature(f.rs.get());
+ UINT stride=h.dev->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV),slot=0;
+ auto dispatch=[&](ID3D12PipelineState *pso,ID3D12Resource *a,ID3D12Resource *b,ID3D12Resource *c,ID3D12Resource *out,UINT w,UINT ht,UINT factor) {
+  auto cpu=f.heap->GetCPUDescriptorHandleForHeapStart();cpu.ptr+=SIZE_T(slot)*4*stride;
+  auto gpu=f.heap->GetGPUDescriptorHandleForHeapStart();gpu.ptr+=UINT64(slot++)*4*stride;
+  for(auto tex:{a,b,c}) {
+   D3D12_SHADER_RESOURCE_VIEW_DESC sd={};sd.Format=tex->GetDesc().Format;sd.ViewDimension=D3D12_SRV_DIMENSION_TEXTURE2D;
+   sd.Shader4ComponentMapping=D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;sd.Texture2D.MipLevels=1;
+   h.dev->CreateShaderResourceView(tex,&sd,cpu);cpu.ptr+=stride;
+  }
+  D3D12_UNORDERED_ACCESS_VIEW_DESC ud={};ud.Format=out->GetDesc().Format;ud.ViewDimension=D3D12_UAV_DIMENSION_TEXTURE2D;
+  h.dev->CreateUnorderedAccessView(out,nullptr,&ud,cpu);
+  UINT constants[]={w,ht,f.w,f.hgt,factor,UINT(reset || !f.valid),v.w,v.hgt};
+  h.list->SetPipelineState(pso);h.list->SetComputeRoot32BitConstants(0,8,constants,0);h.list->SetComputeRootDescriptorTable(1,gpu);
+  h.list->Dispatch((w+7)/8,(ht+7)/8,1);
+ };
+ for(int i=0;i<3;i++) {
+  UINT factor=4u>>i,w=(f.w+factor-1)/factor,ht=(f.hgt+factor-1)/factor;
+  auto pair=f.pairs[i].get(),flow=f.vectors[i].get();
+  auto state=fresh?D3D12_RESOURCE_STATE_COMMON:D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
+  barrier(pair,state,D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+  dispatch(f.down.get(),g_gray_uav,f.previous.get(),g_gray_uav,pair,w,ht,factor);
+  barrier(pair,D3D12_RESOURCE_STATE_UNORDERED_ACCESS,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+  barrier(flow,state,D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+  dispatch(f.flow.get(),pair,pair,i?f.vectors[i-1].get():pair,flow,w,ht,factor);
+  barrier(flow,D3D12_RESOURCE_STATE_UNORDERED_ACCESS,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+ }
+ barrier(v.mv.tex,v.inputs_ready?D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE:D3D12_RESOURCE_STATE_COPY_DEST,D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+ dispatch(f.expand.get(),f.vectors[2].get(),f.vectors[2].get(),f.vectors[2].get(),v.mv.tex,v.w,v.hgt,1);
+ barrier(v.mv.tex,D3D12_RESOURCE_STATE_UNORDERED_ACCESS,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+ barrier(g_gray_uav,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_COPY_SOURCE);
+ barrier(f.previous.get(),D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,D3D12_RESOURCE_STATE_COPY_DEST);
+ h.list->CopyResource(f.previous.get(),g_gray_uav);
+ barrier(f.previous.get(),D3D12_RESOURCE_STATE_COPY_DEST,D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+ barrier(g_gray_uav,D3D12_RESOURCE_STATE_COPY_SOURCE,D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+ auto value=EndCommands();v.inputs_ready=true;f.valid=true;
+ const bool ok=WaitFenceValue(h.fence,value,30000);
+ if(ok) DumpExperimentFlow(f.vectors[2].get());
+ return ok;
+}

--- a/overlay_ui.py
+++ b/overlay_ui.py
@@ -199,6 +199,7 @@ class OverlayMenu:
             "hdr": False,
             # Skip static frames (processing section): no new capture frame -
             # the network idles instead of re-running.
+            "gpu_motion": False,
             "skip_static": True,
             "open_on_start": True,
             "split": 0.0,
@@ -780,6 +781,8 @@ class OverlayMenu:
             # until now the only one answered on another page. The segment
             # sends what the Actions buttons used to send; the list of
             # windows still opens on its own page.
+            toggle("gpu_motion", s["gpu_motion"], bool(self.state.get("gpu_motion", False)), hint=s["gpu_motion_hint"])
+
             section(s["sec_source"])
             in_window = bool(self.state.get("window_mode"))
             segmented("source", "", "window" if in_window else "fullscreen",

--- a/pipeline.py
+++ b/pipeline.py
@@ -55,7 +55,7 @@ from winapi import window_frame_rect
 #: Always let through: the pipeline diagnostics. NS_PHASE=1 adds the
 #: per-frame profiler lines ([phase]/[pw]) on top of these.
 _LOG_ALWAYS = ("[host]", "[pure]", "[arch]", "[cap]", "[dda]", "[present]",
-               "[spout]", "[wgc]", "[video]", "[skip]", "[hdr]")
+               "[spout]", "[wgc]", "[video]", "[skip]", "[hdr]", "[gpu-flow]")
 #: [video] lines that are a heartbeat rather than a diagnostic: the "delivered
 #: frame N" line is printed every 30 frames and would bury the log.
 _LOG_SKIP = ("delivered frame",)
@@ -869,3 +869,12 @@ def request_apply(st, new_scale: float, new_profile: str, new_params: dict,
               f"the last value will be applied")
     else:
         do_restart(st, new_scale, new_profile, new_params, new_small=new_small)
+
+
+def apply_gpu_motion(st, enabled: bool) -> None:
+    st.cfg["gpu_motion"] = bool(enabled)
+    os.environ["NS_GPU_FLOW_EXPERIMENT"] = "1" if enabled else "0"
+    settings_io.save_menu_layout(st)
+    print(f"[main] motion backend: {'GPU LK (experimental)' if enabled else 'CPU DIS'} - restarting worker")
+    teardown_pipeline(st)
+    rebuild_pipeline(st, UI_STRINGS[st.lang]["gpu_motion"] if enabled else "CPU DIS")

--- a/settings_io.py
+++ b/settings_io.py
@@ -254,6 +254,7 @@ def load_config(path: Path) -> dict:
     if lang not in UI_STRINGS:
         lang = DEFAULT_LANG
     cfg["lang"] = lang
+    cfg["gpu_motion"] = cfg.get("gpu_motion") is True
     return cfg
 
 

--- a/settings_io.py
+++ b/settings_io.py
@@ -368,6 +368,7 @@ def _menu_layout_payload(cfg: dict, params: dict, monitor: int, lang: str,
         # Skip static frames: no new frame from the capture - the network
         # idles instead of re-running on the same picture. A per-frame flag,
         # so it survives a restart through the config alone.
+        "gpu_motion": cfg.get("gpu_motion") is True,
         "skip_static": bool(cfg.get("skip_static", True)),
         # The user's saved presets. Without this key "Save preset" wrote
         # everything EXCEPT the preset: the menu said "Preset saved", the
@@ -572,6 +573,7 @@ def menu_payload(st) -> dict:
         "screenshot_dir": st.cfg.get("screenshot_dir") or "",
         "spout": bool(st.cfg.get("spout", False)),
         "hdr": bool(st.cfg.get("hdr", False)),
+        "gpu_motion": st.cfg.get("gpu_motion") is True,
         "skip_static": bool(st.cfg.get("skip_static", True)),
         # Is the network idling on an unchanged screen right now? The
         # worker says so in its log; without this the menu shows a

--- a/startup.py
+++ b/startup.py
@@ -271,6 +271,7 @@ def configure(st) -> None:
     # the bridge costs a full-frame GPU copy on every Present, and it is
     # only useful to someone recording through OBS.
     _apply_spout_env(st.cfg)
+    os.environ["NS_GPU_FLOW_EXPERIMENT"] = "1" if st.cfg.get("gpu_motion") is True else "0"
     # And HDR compatibility, read once per worker process as well.
     _apply_hdr_env(st.cfg)
     # The same for the card: NS_GPU is read once per worker process.

--- a/tests/experiment_gpu_flow.py
+++ b/tests/experiment_gpu_flow.py
@@ -1,0 +1,120 @@
+"""Isolated WGC -> guides -> NR -> optional FG -> present A/B benchmark.
+No changes to user config. Synthetic repeatable scrolling, not a game benchmark.
+"""
+import ctypes, json, os, struct, subprocess, sys, threading, time
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+sys.path.insert(0,str(ROOT))
+import cv2, numpy as np
+import pygame
+import protocol as wire
+from guides import TemporalGuideGenerator
+ctypes.windll.user32.SetProcessDpiAwarenessContext(ctypes.c_void_p(-4))
+cv2.setNumThreads(4)
+OUT=ROOT/'_work/gpu-flow-results';OUT.mkdir(parents=True,exist_ok=True)
+
+def exact(p,n):
+    b=bytearray()
+    while len(b)<n:
+        c=p.read(n-len(b))
+        if not c:raise RuntimeError('worker EOF')
+        b.extend(c)
+    return b
+
+def run(mode,fg=False,quality=False,round_id=0,static=False):
+    w,h=(1280,720) if quality else (2560,1440)
+    screen=pygame.display.set_mode((w,h),pygame.NOFRAME)
+    rng=np.random.default_rng(123)
+    base=cv2.GaussianBlur(rng.integers(0,256,(180,320),dtype=np.uint8),(5,5),0)
+    for y in range(18,180,25):cv2.putText(base,'TEXT 123 Test',(12,y),cv2.FONT_HERSHEY_SIMPLEX,.5,230,1)
+    surfaces=[]
+    for i in range(16):
+        gray=np.roll(base,i,axis=1)
+        rgb=cv2.cvtColor(cv2.resize(gray,(w,h),interpolation=cv2.INTER_LINEAR),cv2.COLOR_GRAY2RGB)
+        surfaces.append(pygame.surfarray.make_surface(rgb.transpose(1,0,2)))
+    screen.blit(surfaces[0],(0,0));pygame.display.flip()
+    tag=f'{mode}-fg{int(fg)}-q{int(quality)}-r{round_id}'+('-static' if static else '')
+    folder=OUT/tag;folder.mkdir(exist_ok=True)
+    env=dict(os.environ,NS_HDR='1',NS_NR_SMALL='1',NS_GPU_FLOW_EXPERIMENT=str(int(mode=='gpu')),
+             NS_FRAMEGEN='0',NS_DLSS_SR='0',NS_PHASE_TIMING='1')
+    if quality and mode=='gpu':env['NS_FLOW_DUMP']=str(folder)
+    else:env.pop('NS_FLOW_DUMP',None)
+    p=subprocess.Popen([str(ROOT/'native/nvngx.dll'),'--live'],cwd=ROOT/'native',env=env,
+          stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE,creationflags=subprocess.CREATE_NO_WINDOW)
+    logs=[];drain=threading.Thread(target=lambda:logs.extend(iter(p.stderr.readline,b'')),daemon=True);drain.start()
+    watchdog=threading.Timer(100,p.kill);watchdog.start()
+    shm=wire.SharedFrameBuffer(w,h);shm.open_gray(320,180)
+    guide=TemporalGuideGenerator(w,h,emit_small=True)
+    def ack(fmt):
+        a=struct.unpack(fmt,exact(p.stdout,struct.calcsize(fmt)))
+        assert a[1 if fmt!=wire.OUT_FMT else 2]==1,a
+        return a
+    rows=[];quality_rows=[];prev=None
+    try:
+        p.stdin.write(struct.pack(wire.HEADER_FMT,wire.VIDEO_MAGIC,w,h,8,0,0,0,1,0,0,1.,1.,1.,-1.,w,h));p.stdin.flush()
+        wire.send_wgc(p,pygame.display.get_wm_info()['window']);ack(wire.WGC_ACK_FMT)
+        wire.send_motion_size(p,320,180);ack(wire.MOTION_ACK_FMT)
+        wire.send_gray(p,320,180,shm.gray_name);ack(wire.GRAY_ACK_FMT)
+        wire.send_window(p,w,h);ack(wire.WINDOW_ACK_FMT)
+        time.sleep(.15)
+        for i in range(24 if quality else 220):
+            pygame.event.pump();screen.blit(surfaces[0 if static else i%16],(0,0));pygame.display.flip()
+            if quality:time.sleep(.025)
+            t0=time.perf_counter()
+            p.stdin.write(struct.pack(wire.FRAME_FMT,wire.CAPTURE_MAGIC,i,0,0,i));p.stdin.flush();ack(wire.OUT_FMT)
+            t1=time.perf_counter();gray=shm.read_gray().copy().reshape(180,320)
+            g=guide.process(gray=gray,compute_motion=mode=='cpu')
+            t2=time.perf_counter()
+            wire.send_frame(p,i,None,g.motion,g.reset,i,no_color=True,motion_small=True,prepared=True,
+                            frame_generation=fg,frame_multiplier=2,dlss_sr=False,want_pixels=False)
+            a=ack(wire.OUT_FMT)
+            if a[3]:exact(p.stdout,a[3])
+            t3=time.perf_counter()
+            changed=prev is not None and np.mean(cv2.absdiff(gray,prev))>.255
+            if i>=40:rows.append({'prepare_ms':(t1-t0)*1000,'guides_ms':(t2-t1)*1000,'worker_ms':(t3-t2)*1000,'total_ms':(t3-t0)*1000,'changed':bool(changed)})
+            if quality and i>0:
+                # Compare against measured translation of the actual captured pair,
+                # rather than assuming WGC delivered the newest drawn source frame.
+                candidates=[]
+                for dy in range(-2,3):
+                    for dx in range(-16,17):
+                        shifted=np.roll(prev,(dy,dx),axis=(0,1))
+                        error=float(np.mean(cv2.absdiff(shifted,gray)[8:-8,20:-20]))
+                        candidates.append((error,dx,dy))
+                residual,dx,dy=min(candidates)
+                response=1.0-residual/255.0
+                target=-np.array([dx,dy],dtype=np.float32)
+                if mode=='gpu':
+                    fpath=folder/f'flow-{i:04d}.bin'
+                    vectors=np.fromfile(fpath,np.float16).reshape(180,320,2).astype(np.float32)
+                else:
+                    vectors=g.motion.astype(np.float32)/np.array([w/320,h/180])
+                inner=vectors[16:-16,24:-24]
+                err=np.linalg.norm(inner-target,axis=2)
+                quality_rows.append({'target':target.tolist(),'phase_response':response,'median_epe':float(np.median(err)),'p95_epe':float(np.percentile(err,95)),'median_vector':np.median(inner,axis=(0,1)).tolist(),'reset':bool(g.reset)})
+            prev=gray
+        p.stdin.close();p.wait(timeout=15);assert p.returncode==0,p.returncode
+    finally:
+        if p.poll() is None:p.kill();p.wait()
+        watchdog.cancel();drain.join(timeout=2);shm.close()
+        (folder/'worker.log').write_bytes(b''.join(logs))
+    result={'mode':mode,'fg':fg,'quality':quality,'round':round_id,'static':static,'rows':rows,'quality_rows':quality_rows}
+    if rows:
+        result['summary']={k:{'median':float(np.median([r[k] for r in rows])),'mean':float(np.mean([r[k] for r in rows])),'p95':float(np.percentile([r[k] for r in rows],95))} for k in ['prepare_ms','guides_ms','worker_ms','total_ms']}
+        result['changed_fraction']=float(np.mean([r['changed'] for r in rows]))
+    (folder/'result.json').write_text(json.dumps(result,indent=2))
+    print(tag,json.dumps(result.get('summary',quality_rows[-3:])),flush=True)
+    return result
+
+if __name__=='__main__':
+    pygame.init()
+    try:
+        if '--static' in sys.argv:
+            for fg in [False,True]:
+                for m in ['cpu','gpu']:run(m,fg=fg,static=True)
+        elif '--quality' in sys.argv:
+            for m in ['cpu','gpu']:run(m,quality=True)
+        else:
+            for fg in [False,True]:
+                for i,m in enumerate(['cpu','gpu','gpu','cpu']):run(m,fg=fg,round_id=i)
+    finally:pygame.quit()

--- a/tests/experiment_gpu_flow.py
+++ b/tests/experiment_gpu_flow.py
@@ -1,4 +1,4 @@
-"""Isolated WGC -> guides -> NR -> optional FG -> present A/B benchmark.
+"""Isolated WGC -> guides -> NR -> present A/B benchmark.
 No changes to user config. Synthetic repeatable scrolling, not a game benchmark.
 """
 import ctypes, json, os, struct, subprocess, sys, threading, time
@@ -21,7 +21,7 @@ def exact(p,n):
         b.extend(c)
     return b
 
-def run(mode,fg=False,quality=False,round_id=0,static=False):
+def run(mode,quality=False,round_id=0,static=False):
     w,h=(1280,720) if quality else (2560,1440)
     screen=pygame.display.set_mode((w,h),pygame.NOFRAME)
     rng=np.random.default_rng(123)
@@ -33,10 +33,10 @@ def run(mode,fg=False,quality=False,round_id=0,static=False):
         rgb=cv2.cvtColor(cv2.resize(gray,(w,h),interpolation=cv2.INTER_LINEAR),cv2.COLOR_GRAY2RGB)
         surfaces.append(pygame.surfarray.make_surface(rgb.transpose(1,0,2)))
     screen.blit(surfaces[0],(0,0));pygame.display.flip()
-    tag=f'{mode}-fg{int(fg)}-q{int(quality)}-r{round_id}'+('-static' if static else '')
+    tag=f'{mode}-q{int(quality)}-r{round_id}'+('-static' if static else '')
     folder=OUT/tag;folder.mkdir(exist_ok=True)
     env=dict(os.environ,NS_HDR='1',NS_NR_SMALL='1',NS_GPU_FLOW_EXPERIMENT=str(int(mode=='gpu')),
-             NS_FRAMEGEN='0',NS_DLSS_SR='0',NS_PHASE_TIMING='1')
+             NS_PHASE_TIMING='1')
     if quality and mode=='gpu':env['NS_FLOW_DUMP']=str(folder)
     else:env.pop('NS_FLOW_DUMP',None)
     p=subprocess.Popen([str(ROOT/'native/nvngx.dll'),'--live'],cwd=ROOT/'native',env=env,
@@ -61,15 +61,14 @@ def run(mode,fg=False,quality=False,round_id=0,static=False):
             pygame.event.pump();screen.blit(surfaces[0 if static else i%16],(0,0));pygame.display.flip()
             if quality:time.sleep(.025)
             t0=time.perf_counter()
-            p.stdin.write(struct.pack(wire.FRAME_FMT,wire.CAPTURE_MAGIC,i,0,0,i));p.stdin.flush();ack(wire.OUT_FMT)
             t1=time.perf_counter();gray=shm.read_gray().copy().reshape(180,320)
             g=guide.process(gray=gray,compute_motion=mode=='cpu')
             t2=time.perf_counter()
-            wire.send_frame(p,i,None,g.motion,g.reset,i,no_color=True,motion_small=True,prepared=True,
-                            frame_generation=fg,frame_multiplier=2,dlss_sr=False,want_pixels=False)
+            wire.send_frame(p,i,None,g.motion,g.reset,i,no_color=True,motion_small=True,want_pixels=False)
             a=ack(wire.OUT_FMT)
             if a[3]:exact(p.stdout,a[3])
             t3=time.perf_counter()
+            if quality and mode == "gpu": gray=shm.read_gray().copy().reshape(180,320)
             changed=prev is not None and np.mean(cv2.absdiff(gray,prev))>.255
             if i>=40:rows.append({'prepare_ms':(t1-t0)*1000,'guides_ms':(t2-t1)*1000,'worker_ms':(t3-t2)*1000,'total_ms':(t3-t0)*1000,'changed':bool(changed)})
             if quality and i>0:
@@ -98,7 +97,7 @@ def run(mode,fg=False,quality=False,round_id=0,static=False):
         if p.poll() is None:p.kill();p.wait()
         watchdog.cancel();drain.join(timeout=2);shm.close()
         (folder/'worker.log').write_bytes(b''.join(logs))
-    result={'mode':mode,'fg':fg,'quality':quality,'round':round_id,'static':static,'rows':rows,'quality_rows':quality_rows}
+    result={'mode':mode,'quality':quality,'round':round_id,'static':static,'rows':rows,'quality_rows':quality_rows}
     if rows:
         result['summary']={k:{'median':float(np.median([r[k] for r in rows])),'mean':float(np.mean([r[k] for r in rows])),'p95':float(np.percentile([r[k] for r in rows],95))} for k in ['prepare_ms','guides_ms','worker_ms','total_ms']}
         result['changed_fraction']=float(np.mean([r['changed'] for r in rows]))
@@ -110,11 +109,9 @@ if __name__=='__main__':
     pygame.init()
     try:
         if '--static' in sys.argv:
-            for fg in [False,True]:
-                for m in ['cpu','gpu']:run(m,fg=fg,static=True)
+            for m in ['cpu','gpu']:run(m,static=True)
         elif '--quality' in sys.argv:
             for m in ['cpu','gpu']:run(m,quality=True)
         else:
-            for fg in [False,True]:
-                for i,m in enumerate(['cpu','gpu','gpu','cpu']):run(m,fg=fg,round_id=i)
+            for i,m in enumerate(['cpu','gpu','gpu','cpu']):run(m,round_id=i)
     finally:pygame.quit()

--- a/tests/test_gpu_motion_controls.py
+++ b/tests/test_gpu_motion_controls.py
@@ -1,0 +1,51 @@
+"""Regression: state payload must reach the checkbox; Russian must survive encoding."""
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import pygame
+import commands
+import pipeline
+import settings_io
+from i18n import STRINGS
+from test_ui_buttons import build, paint, find, click
+
+def main():
+    pygame.init()
+    try:
+        menu = build()
+        menu.set_state({"lang": "ru"})
+        st = SimpleNamespace(cfg={"profile": "Natural"}, lang="ru")
+        with patch.dict(os.environ), patch.object(settings_io, "save_menu_layout"), \
+             patch.object(pipeline, "teardown_pipeline"), patch.object(pipeline, "rebuild_pipeline"):
+            for before in [False, True, False]:
+                st.cfg["gpu_motion"] = before
+                menu.set_state(st.cfg)
+                paint(menu)
+                item = find(menu, "toggle", "gpu_motion")
+                assert item is not None
+                assert bool(item.value) == before
+                assert item.extra["label"] == "Расчёт движения на GPU (эксперимент)"
+                assert "?" not in item.extra["hint"]
+                action, = click(menu, item)
+                commands.apply_menu_action(st, action)
+                assert st.cfg["gpu_motion"] is not before
+                assert os.environ["NS_GPU_FLOW_EXPERIMENT"] == str(int(not before))
+                menu.set_state(st.cfg)
+                paint(menu)
+                assert bool(find(menu, "toggle", "gpu_motion").value) is not before
+                payload = settings_io._menu_layout_payload(
+                    st.cfg, {"intensity": 1., "local_tone": 1., "local_structure": 1., "skin_structure": -1.},
+                    0, "ru", 1., 0., True, False, menu)
+                assert payload["gpu_motion"] is not before
+        print("PASS: checkbox on/off, restart environment, persisted payload and Russian text")
+    finally:
+        pygame.quit()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add an opt-in GPU motion-estimation backend for the existing neural renderer. The checkbox defaults off; switching restarts the worker, and disabling it restores CPU DIS. This PR is based directly on current main (v1.8.0) and contains no Super Resolution, Frame Generation, UI detection, or library update checker.

The worker computes a three-level Lucas-Kanade flow pyramid on D3D12 and writes the neural motion texture. Gray readback and the existing capture protocol remain in place; this is not a fully GPU-resident capture pipeline. No extra NVIDIA library is required.

This is experimental: small-translation tests are accurate, but large displacements can produce badly incorrect motion vectors and visible distortion. The UI warns about fast motion. Earlier combined-preview tests and user feedback indicated improved throughput on moving content; those results are not a standalone-main FPS guarantee.

Validation on RTX 5080: native build; GPU checkbox state, restart, persistence and Russian-text regression; existing UI controls and state-contract tests; standalone CPU/GPU synthetic quality runs. Known large-motion errors are reported, not presented as a passing quality gate. Reproduction details are in docs/GPU_MOTION_EXPERIMENT.md.
